### PR TITLE
Milestone 3c: recommendation typing & explanation discipline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ artifacts/**/*.pdf
 !artifacts/**/templates/**
 !artifacts/**/README.md
 !artifacts/**/.keep
+
+# Local-only Codex/LLM handover notes (do not commit)
+artifacts/.codex/

--- a/agent/lib/domain/decisionSnapshot.ts
+++ b/agent/lib/domain/decisionSnapshot.ts
@@ -9,9 +9,8 @@
 
 export type RecommendationType =
   | "DO_NOTHING"
+  | "REBALANCE"
   | "REBALANCE_VIA_CONTRIBUTIONS"
-  | "PARTIAL_REBALANCE"
-  | "FULL_REBALANCE"
   | "DEFER_AND_REVIEW"
   | "ASK_CLARIFYING_QUESTIONS";
 

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -345,7 +345,7 @@ describe("runDecision", () => {
     expect(result.snapshot.explanation.decision_summary).toContain("Guardrails override");
   });
 
-  it("downgrades when policy_basis does not reference policy values", async () => {
+  it("injects deterministic policy basis even when model response is generic", async () => {
     forcedResponse = JSON.stringify({
       recommendation_type: "DO_NOTHING",
       recommendation_summary: "No action.",
@@ -370,6 +370,8 @@ describe("runDecision", () => {
       ],
     });
 
-    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+    expect(result.snapshot.recommendation.type).toBe("DO_NOTHING");
+    expect(result.snapshot.explanation.policy_basis).toContain("Targets: equities 0.8");
+    expect(result.snapshot.explanation.policy_basis).toContain("Bands: equities 0.05");
   });
 });

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -314,4 +314,62 @@ describe("runDecision", () => {
     expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
     expect(result.snapshot.snapshot_id).toBeTruthy();
   });
+
+  it("explains guardrail overrides in the snapshot explanation", async () => {
+    forcedResponse = JSON.stringify({
+      recommendation_type: "DO_NOTHING",
+      recommendation_summary: "No action.",
+      proposed_actions: [],
+      explanation: {
+        decision_summary: "Model tried to do nothing.",
+        relevant_portfolio_state: "Inputs were parsed from the request.",
+        policy_basis:
+          "Targets: equities 0.8, bonds 0.15, cash 0.05. Bands: equities 0.05, bonds 0.04, cash 0.02.",
+        reasoning_and_tradeoffs: "Model output prior to guardrails.",
+        uncertainty_and_confidence: "Medium confidence.",
+        next_review_or_trigger: "Review if inputs change.",
+      },
+    });
+
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate against policy. Portfolio state: Equities 90%, Bonds 8%, Cash 2%. No new cash flows.",
+        },
+      ],
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+    expect(result.snapshot.explanation.decision_summary).toContain("Guardrails override");
+  });
+
+  it("downgrades when policy_basis does not reference policy values", async () => {
+    forcedResponse = JSON.stringify({
+      recommendation_type: "DO_NOTHING",
+      recommendation_summary: "No action.",
+      proposed_actions: [],
+      explanation: {
+        decision_summary: "Within tolerance.",
+        relevant_portfolio_state: "Inputs were parsed from the request.",
+        policy_basis: "Policy allows no action.",
+        reasoning_and_tradeoffs: "No action needed.",
+        uncertainty_and_confidence: "High confidence.",
+        next_review_or_trigger: "Review if inputs change.",
+      },
+    });
+
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the policy. Portfolio state: Equities 78%, Bonds 16%, Cash 6%. No new contributions or withdrawals.",
+        },
+      ],
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+  });
 });

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { runDecision } from "@/lib/services/decisionService";
+
+let forcedResponse: string | null = null;
 
 vi.mock("@/lib/infra/policyLoader", () => ({
   loadPolicy: () => ({
@@ -28,30 +30,43 @@ vi.mock("@/lib/infra/policyLoader", () => ({
 
 vi.mock("@/lib/infra/mastra", () => ({
   generateAssistantReply: vi.fn(async ({ systemPrompt }: { systemPrompt: string }) => {
+    if (forcedResponse !== null) {
+      return forcedResponse;
+    }
+
     const pickRecommendation = (): string => {
       if (systemPrompt.includes("Portfolio state has NOT been provided.")) {
         return "ASK_CLARIFYING_QUESTIONS";
       }
-      if (systemPrompt.includes("weights: equities=0.73, bonds=0.2, cash=0.07")) {
-        return "ASK_CLARIFYING_QUESTIONS";
-      }
-      if (systemPrompt.includes("pending_contributions_gbp: 5000")) {
+      if (
+        systemPrompt.includes("pending_contributions_gbp: 2000") ||
+        systemPrompt.includes("pending_contributions_gbp: 5000")
+      ) {
         return "REBALANCE_VIA_CONTRIBUTIONS";
       }
       if (systemPrompt.includes("bands_breached: true")) {
-        return "FULL_REBALANCE";
+        return "REBALANCE";
       }
       return "DO_NOTHING";
     };
 
+    const recommendation_type = pickRecommendation();
+    const decision_summary =
+      recommendation_type === "ASK_CLARIFYING_QUESTIONS"
+        ? "Missing inputs; please provide portfolio weights and cash flows."
+        : recommendation_type === "DEFER_AND_REVIEW"
+          ? "Defer and review required before proceeding."
+          : "Decision follows the investment policy guardrails.";
+
     return JSON.stringify({
-      recommendation_type: pickRecommendation(),
+      recommendation_type,
       recommendation_summary: "Policy-aligned recommendation based on provided inputs.",
       proposed_actions: [],
       explanation: {
-        decision_summary: "Decision follows the investment policy guardrails.",
+        decision_summary,
         relevant_portfolio_state: "Inputs were parsed from the request.",
-        policy_basis: "Policy targets and bands govern rebalancing decisions.",
+        policy_basis:
+          "Targets: equities 0.8, bonds 0.15, cash 0.05. Bands: equities 0.05, bonds 0.04, cash 0.02. Policy ape-policy v0.1-test (test).",
         reasoning_and_tradeoffs: "Guardrails prevent unnecessary action.",
         uncertainty_and_confidence: "High confidence given deterministic inputs.",
         next_review_or_trigger: "Review if inputs or cash flows change.",
@@ -59,6 +74,10 @@ vi.mock("@/lib/infra/mastra", () => ({
     });
   }),
 }));
+
+beforeEach(() => {
+  forcedResponse = null;
+});
 
 describe("runDecision", () => {
   it("asks for clarification when portfolio state is missing (scenario 1)", async () => {
@@ -141,7 +160,7 @@ describe("runDecision", () => {
     });
   });
 
-  it("recommends full rebalance when drift is out of band and no cash flows (scenario 3)", async () => {
+  it("recommends rebalance when drift is out of band and no cash flows (scenario 3)", async () => {
     const result = await runDecision({
       messages: [
         {
@@ -152,7 +171,7 @@ describe("runDecision", () => {
       ],
     });
 
-    expect(result.snapshot.recommendation.type).toBe("FULL_REBALANCE");
+    expect(result.snapshot.recommendation.type).toBe("REBALANCE");
   });
 
   it("recommends rebalancing via contributions when drift is out of band with contributions (scenario 4)", async () => {
@@ -181,5 +200,118 @@ describe("runDecision", () => {
     });
 
     expect(result.snapshot.recommendation.type).toBe("DO_NOTHING");
+  });
+
+  it("recommends rebalancing via contributions when in-band with contributions (3c prompt C)", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate against policy. Portfolio state: Equities 78%, Bonds 16%, Cash 6%. Planned contribution: £2,000.",
+        },
+      ],
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("REBALANCE_VIA_CONTRIBUTIONS");
+  });
+
+  it("keeps DO_NOTHING regardless of prompt tone (prompt invariance)", async () => {
+    const neutral = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the policy. Portfolio state: Equities 78%, Bonds 16%, Cash 6%. No new contributions or withdrawals.",
+        },
+      ],
+    });
+
+    const emotional = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Please, I am really worried and want action. Evaluate my portfolio: Equities 78%, Bonds 16%, Cash 6%. No new contributions or withdrawals.",
+        },
+      ],
+    });
+
+    expect(neutral.snapshot.recommendation.type).toBe("DO_NOTHING");
+    expect(emotional.snapshot.recommendation.type).toBe("DO_NOTHING");
+  });
+
+  it("downgrades when model returns an unknown recommendation type", async () => {
+    forcedResponse = JSON.stringify({
+      recommendation_type: "GO_ALL_IN",
+      recommendation_summary: "Invalid type.",
+      proposed_actions: [],
+      explanation: {
+        decision_summary: "Invalid type supplied.",
+        relevant_portfolio_state: "Inputs were parsed from the request.",
+        policy_basis:
+          "Targets: equities 0.8, bonds 0.15, cash 0.05. Bands: equities 0.05, bonds 0.04, cash 0.02.",
+        reasoning_and_tradeoffs: "Invalid type.",
+        uncertainty_and_confidence: "Low confidence.",
+        next_review_or_trigger: "Retry.",
+      },
+    });
+
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the policy. Portfolio state: Equities 78%, Bonds 16%, Cash 6%. No new contributions or withdrawals.",
+        },
+      ],
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+  });
+
+  it("downgrades when required explanation fields are missing", async () => {
+    forcedResponse = JSON.stringify({
+      recommendation_type: "DO_NOTHING",
+      recommendation_summary: "Missing policy basis.",
+      proposed_actions: [],
+      explanation: {
+        decision_summary: "Decision follows the investment policy guardrails.",
+        relevant_portfolio_state: "Inputs were parsed from the request.",
+        policy_basis: "",
+        reasoning_and_tradeoffs: "Guardrails prevent unnecessary action.",
+        uncertainty_and_confidence: "High confidence.",
+        next_review_or_trigger: "Review if inputs change.",
+      },
+    });
+
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the policy. Portfolio state: Equities 78%, Bonds 16%, Cash 6%. No new contributions or withdrawals.",
+        },
+      ],
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+  });
+
+  it("returns a safe snapshot when the model output is invalid JSON", async () => {
+    forcedResponse = "not-json";
+
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the policy. Portfolio state: Equities 78%, Bonds 16%, Cash 6%. No new contributions or withdrawals.",
+        },
+      ],
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+    expect(result.snapshot.snapshot_id).toBeTruthy();
   });
 });

--- a/agent/lib/services/decisionService.ts
+++ b/agent/lib/services/decisionService.ts
@@ -696,8 +696,11 @@ function enforceExplanationContract(args: {
     warnings.push(
       `recommendation_type mismatch (expected ${expectedType}, got ${model.recommendation_type}).`
     );
+    const mismatchReason = model.explanation.decision_summary.includes("Guardrails override")
+      ? model.explanation.decision_summary
+      : "Recommendation type mismatch.";
     return {
-      model: downgradeToDefer(model, policy, "Recommendation type mismatch."),
+      model: downgradeToDefer(model, policy, mismatchReason),
       warnings,
       overridden: true,
     };

--- a/agent/lib/services/decisionService.ts
+++ b/agent/lib/services/decisionService.ts
@@ -19,6 +19,7 @@ import crypto from "node:crypto";
 import type { ChatRequest } from "@/lib/domain/chat";
 import type { DecisionSnapshot, RecommendationType } from "@/lib/domain/decisionSnapshot";
 import type { PortfolioStateInput } from "@/lib/domain/portfolioState";
+import type { PolicyJson } from "@/lib/infra/policyLoader";
 
 import { loadPolicy } from "@/lib/infra/policyLoader";
 import { generateAssistantReply } from "@/lib/infra/mastra";
@@ -225,6 +226,18 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
    */
   const driftResult = state && hasCompleteWeights(state) ? computeDrift(policy, state) : null;
 
+  const pendingContrib = state?.cash_flows.pending_contributions_gbp ?? null;
+  const pendingWithdraw = state?.cash_flows.pending_withdrawals_gbp ?? null;
+  const hasCashFlows = (pendingContrib ?? 0) > 0 || (pendingWithdraw ?? 0) > 0;
+
+  const expectedRecommendationType: RecommendationType = !state || !driftResult
+    ? "ASK_CLARIFYING_QUESTIONS"
+    : hasCashFlows
+      ? "REBALANCE_VIA_CONTRIBUTIONS"
+      : driftResult.bands_breached
+        ? "REBALANCE"
+        : "DO_NOTHING";
+
   /**
    * ------------------------------------------------------------------
    * Build LLM system prompt (minimal authority)
@@ -235,7 +248,7 @@ Return STRICT JSON ONLY (no markdown, no commentary).
 
 Schema:
 {
-  "recommendation_type": "DO_NOTHING|REBALANCE_VIA_CONTRIBUTIONS|PARTIAL_REBALANCE|FULL_REBALANCE|DEFER_AND_REVIEW|ASK_CLARIFYING_QUESTIONS",
+  "recommendation_type": "DO_NOTHING|REBALANCE|REBALANCE_VIA_CONTRIBUTIONS|DEFER_AND_REVIEW|ASK_CLARIFYING_QUESTIONS",
   "recommendation_summary": "one short sentence",
   "explanation": {
     "decision_summary": "string",
@@ -261,6 +274,7 @@ Important rules:
 - Rebalancing is a risk-management tool, not return optimisation.
 - NEVER invent missing weights or cash flows.
 - Use the policy targets and bands provided below; do not invent targets or bands.
+- The recommendation type is already decided: ${expectedRecommendationType}. Do NOT change it; only explain it.
 
 Policy (authoritative):
 - target_weights: equities=${policy.strategic_asset_allocation.target_weights.EQUITIES}, bonds=${policy.strategic_asset_allocation.target_weights.BONDS}, cash=${policy.strategic_asset_allocation.target_weights.CASH}
@@ -351,9 +365,8 @@ Portfolio state has NOT been provided.
 
     const allowedTypes: RecommendationType[] = [
       "DO_NOTHING",
+      "REBALANCE",
       "REBALANCE_VIA_CONTRIBUTIONS",
-      "PARTIAL_REBALANCE",
-      "FULL_REBALANCE",
       "DEFER_AND_REVIEW",
       "ASK_CLARIFYING_QUESTIONS",
     ];
@@ -455,7 +468,17 @@ Portfolio state has NOT been provided.
     console.warn("[APE] Guardrails applied:", guard.warnings);
   }
 
-  const finalModel = guard.model;
+  const contract = enforceExplanationContract({
+    expectedType: expectedRecommendationType,
+    model: guard.model,
+    policy,
+  });
+
+  if (contract.overridden || contract.warnings.length) {
+    console.warn("[APE] Explanation contract applied:", contract.warnings);
+  }
+
+  const finalModel = contract.model;
 
   /**
    * ------------------------------------------------------------------
@@ -576,6 +599,8 @@ Portfolio state has NOT been provided.
         usedFallback ? "Model JSON invalid: used fallback before guardrails." : null,
         guard.overridden ? "Guardrails overrode model output." : null,
         guard.warnings.length ? `Guardrails warnings: ${guard.warnings.join(" | ")}` : null,
+        contract.overridden ? "Explanation contract forced DEFER_AND_REVIEW." : null,
+        contract.warnings.length ? `Explanation warnings: ${contract.warnings.join(" | ")}` : null,
         auditWarnings.length ? `Input warnings: ${auditWarnings.join(" | ")}` : null,
         "#TODO: add structured audit.guardrails when schema supports it.",
       ]
@@ -592,4 +617,162 @@ Portfolio state has NOT been provided.
  */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+type ExplanationContractResult = {
+  model: ModelDecision;
+  warnings: string[];
+  overridden: boolean;
+};
+
+const REQUIRED_EXPLANATION_FIELDS: Record<
+  RecommendationType,
+  Array<keyof DecisionSnapshot["explanation"]>
+> = {
+  DO_NOTHING: [
+    "decision_summary",
+    "policy_basis",
+    "relevant_portfolio_state",
+    "reasoning_and_tradeoffs",
+    "uncertainty_and_confidence",
+    "next_review_or_trigger",
+  ],
+  REBALANCE: [
+    "decision_summary",
+    "policy_basis",
+    "relevant_portfolio_state",
+    "reasoning_and_tradeoffs",
+    "uncertainty_and_confidence",
+    "next_review_or_trigger",
+  ],
+  REBALANCE_VIA_CONTRIBUTIONS: [
+    "decision_summary",
+    "policy_basis",
+    "relevant_portfolio_state",
+    "reasoning_and_tradeoffs",
+    "uncertainty_and_confidence",
+    "next_review_or_trigger",
+  ],
+  ASK_CLARIFYING_QUESTIONS: [
+    "decision_summary",
+    "policy_basis",
+    "reasoning_and_tradeoffs",
+    "uncertainty_and_confidence",
+    "next_review_or_trigger",
+  ],
+  DEFER_AND_REVIEW: [
+    "decision_summary",
+    "policy_basis",
+    "reasoning_and_tradeoffs",
+    "uncertainty_and_confidence",
+    "next_review_or_trigger",
+  ],
+};
+
+function enforceExplanationContract(args: {
+  expectedType: RecommendationType;
+  model: ModelDecision;
+  policy: PolicyJson;
+}): ExplanationContractResult {
+  const { expectedType, model, policy } = args;
+  const warnings: string[] = [];
+
+  if (model.recommendation_type !== expectedType) {
+    warnings.push(
+      `recommendation_type mismatch (expected ${expectedType}, got ${model.recommendation_type}).`
+    );
+    return {
+      model: downgradeToDefer(model, policy, "Recommendation type mismatch."),
+      warnings,
+      overridden: true,
+    };
+  }
+
+  const required = REQUIRED_EXPLANATION_FIELDS[expectedType];
+  for (const key of required) {
+    const value = model.explanation[key];
+    if (!value || typeof value !== "string" || value.trim().length === 0) {
+      warnings.push(`explanation.${key} is missing or blank.`);
+    }
+  }
+  if (warnings.length) {
+    return {
+      model: downgradeToDefer(model, policy, "Explanation contract violation; safe fallback applied."),
+      warnings,
+      overridden: true,
+    };
+  }
+
+  if (!policyBasisReferencesPolicy(model.explanation.policy_basis, policy)) {
+    warnings.push("policy_basis does not reference required policy values.");
+    return {
+      model: downgradeToDefer(model, policy, "Explanation contract violation; policy values missing."),
+      warnings,
+      overridden: true,
+    };
+  }
+
+  if (expectedType === "ASK_CLARIFYING_QUESTIONS") {
+    const text = `${model.explanation.decision_summary} ${model.explanation.policy_basis} ${model.explanation.reasoning_and_tradeoffs}`.toLowerCase();
+    if (!text.includes("missing") && !text.includes("clarify") && !text.includes("provide")) {
+      warnings.push("ASK_CLARIFYING_QUESTIONS lacks explicit missing-input disclosure.");
+      return {
+        model: downgradeToDefer(model, policy, "Missing-input disclosure required."),
+        warnings,
+        overridden: true,
+      };
+    }
+  }
+
+  if (expectedType === "DEFER_AND_REVIEW") {
+    const text = `${model.explanation.decision_summary} ${model.explanation.policy_basis} ${model.explanation.reasoning_and_tradeoffs}`.toLowerCase();
+    if (!text.includes("defer") && !text.includes("review")) {
+      warnings.push("DEFER_AND_REVIEW lacks explicit defer/review rationale.");
+      return {
+        model: downgradeToDefer(model, policy, "Defer rationale required."),
+        warnings,
+        overridden: true,
+      };
+    }
+  }
+
+  return { model, warnings, overridden: false };
+}
+
+function policyBasisReferencesPolicy(policyBasis: string, policy: PolicyJson): boolean {
+  const targets = policy.strategic_asset_allocation.target_weights;
+  const bands = policy.rebalancing_policy.absolute_bands;
+  const values = [
+    targets.EQUITIES,
+    targets.BONDS,
+    targets.CASH,
+    bands.EQUITIES,
+    bands.BONDS,
+    bands.CASH,
+  ];
+
+  return values.every((value) => valueMentioned(policyBasis, value));
+}
+
+function valueMentioned(text: string, value: number): boolean {
+  const decimal = value.toString();
+  const percent = (value * 100).toString();
+  return text.includes(decimal) || text.includes(percent);
+}
+
+function downgradeToDefer(model: ModelDecision, policy: PolicyJson, reason: string): ModelDecision {
+  return {
+    ...model,
+    recommendation_type: "DEFER_AND_REVIEW",
+    recommendation_summary: "Defer and review required before proceeding.",
+    proposed_actions: [],
+    explanation: {
+      decision_summary: reason,
+      relevant_portfolio_state: model.explanation.relevant_portfolio_state || "Not provided.",
+      policy_basis: `Policy ${policy.policy_id} v${policy.policy_version} (${policy.source}).`,
+      reasoning_and_tradeoffs: "Cannot safely justify action; returning defer.",
+      uncertainty_and_confidence: "Low confidence due to contract violation.",
+      next_review_or_trigger: "Fix explanation contract and retry.",
+    },
+  };
 }

--- a/agent/lib/services/decisionService.ts
+++ b/agent/lib/services/decisionService.ts
@@ -344,7 +344,7 @@ Portfolio state has NOT been provided.
     explanation: {
       decision_summary: "Model returned invalid JSON; raw output was logged for review.",
       relevant_portfolio_state: state ? "Structured portfolio state was provided." : "No portfolio state.",
-      policy_basis: "Cannot provide a policy-aligned recommendation without a valid model response.",
+      policy_basis: buildPolicyBasis(policy),
       reasoning_and_tradeoffs:
         "Returning a safe default avoids acting on malformed output. A retry can provide a valid response.",
       uncertainty_and_confidence: "High uncertainty due to invalid model output.",
@@ -437,7 +437,7 @@ Portfolio state has NOT been provided.
             explanation: {
               decision_summary: exp["decision_summary"] as string,
               relevant_portfolio_state: exp["relevant_portfolio_state"] as string,
-              policy_basis: exp["policy_basis"] as string,
+              policy_basis: buildPolicyBasis(policy),
               reasoning_and_tradeoffs: exp["reasoning_and_tradeoffs"] as string,
               uncertainty_and_confidence: exp["uncertainty_and_confidence"] as string,
               next_review_or_trigger: exp["next_review_or_trigger"] as string,
@@ -772,6 +772,12 @@ function policyBasisReferencesPolicy(policyBasis: string, policy: PolicyJson): b
   return values.every((value) => valueMentioned(policyBasis, value));
 }
 
+function buildPolicyBasis(policy: PolicyJson): string {
+  const targets = policy.strategic_asset_allocation.target_weights;
+  const bands = policy.rebalancing_policy.absolute_bands;
+  return `Policy ${policy.policy_id} v${policy.policy_version} (${policy.source}). Targets: equities ${targets.EQUITIES}, bonds ${targets.BONDS}, cash ${targets.CASH}. Bands: equities ${bands.EQUITIES}, bonds ${bands.BONDS}, cash ${bands.CASH}.`;
+}
+
 function valueMentioned(text: string, value: number): boolean {
   const decimal = value.toString();
   const percent = (value * 100).toString();
@@ -787,7 +793,7 @@ function downgradeToDefer(model: ModelDecision, policy: PolicyJson, reason: stri
     explanation: {
       decision_summary: reason,
       relevant_portfolio_state: model.explanation.relevant_portfolio_state || "Not provided.",
-      policy_basis: `Policy ${policy.policy_id} v${policy.policy_version} (${policy.source}).`,
+      policy_basis: buildPolicyBasis(policy),
       reasoning_and_tradeoffs: "Cannot safely justify action; returning defer.",
       uncertainty_and_confidence: "Low confidence due to contract violation.",
       next_review_or_trigger: "Fix explanation contract and retry.",

--- a/agent/lib/services/decisionService.ts
+++ b/agent/lib/services/decisionService.ts
@@ -468,9 +468,24 @@ Portfolio state has NOT been provided.
     console.warn("[APE] Guardrails applied:", guard.warnings);
   }
 
+  const guardedModel = guard.overridden
+    ? {
+        ...guard.model,
+        explanation: {
+          ...guard.model.explanation,
+          decision_summary: `Guardrails override applied. ${guard.warnings.join(" ")}`.trim(),
+          policy_basis: `${guard.model.explanation.policy_basis} Guardrails enforced: ${guard.warnings.join(" ")}`.trim(),
+          reasoning_and_tradeoffs:
+            "Guardrails overrode the model output to keep the recommendation policy-aligned.",
+          uncertainty_and_confidence:
+            "High confidence in guardrail enforcement; model output was overridden.",
+        },
+      }
+    : guard.model;
+
   const contract = enforceExplanationContract({
     expectedType: expectedRecommendationType,
-    model: guard.model,
+    model: guardedModel,
     policy,
   });
 

--- a/artifacts/tests/milestone-3c/README.md
+++ b/artifacts/tests/milestone-3c/README.md
@@ -117,10 +117,10 @@ Record manual test results here so milestone status is traceable.
 
 | Date (YYYY-MM-DD) | Scenario | Result | Notes |
 |---|---|---|---|
-|  | Scenario 1 — In-band, no cash flows |  |  |
-|  | Scenario 2 — Out-of-band, no cash flows |  |  |
-|  | Scenario 3 — In-band with contribution |  |  |
-|  | Scenario 4 — Missing portfolio state |  |  |
-|  | Scenario 5 — Prompt invariance |  |  |
+| 2026-02-01 | Scenario 1 — In-band, no cash flows | PASS |  |
+| 2026-02-01 | Scenario 2 — Out-of-band, no cash flows | PASS |  |
+| 2026-02-01 | Scenario 3 — In-band with contribution | PASS |  |
+| 2026-02-01 | Scenario 4 — Missing portfolio state | PASS |  |
+| 2026-02-01 | Scenario 5 — Prompt invariance | PASS |  |
 
 ---

--- a/artifacts/tests/milestone-3c/README.md
+++ b/artifacts/tests/milestone-3c/README.md
@@ -1,0 +1,126 @@
+# Milestone 3c — Manual Test Scenarios  
+**Recommendation Typing & Explanation Discipline**
+
+---
+
+## Purpose
+
+This folder contains **manual acceptance test scenarios** for **Milestone 3c** of the  
+**AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)**.
+
+Milestone 3c focuses on ensuring that:
+
+- Recommendation types are **closed, deterministic, and immutable**
+- Explanations are **complete, policy-referential, and non-speculative**
+- Prompt phrasing cannot change meaning (prompt invariance)
+- Invalid or incomplete explanations downgrade to safe defaults
+
+These scenarios are executed **manually via the GUI** and are intended to be
+**promotable to automated tests** in later milestones.
+
+---
+
+## Scope (What Is Tested)
+
+Included in scope:
+
+- Closed recommendation enum enforcement
+- Deterministic type computation
+- Explanation contract completeness
+- Policy-referential explanations
+- Safe downgrade behavior
+
+Explicitly out of scope:
+
+- New recommendation types
+- UX polish or narrative style improvements
+- Optimisation logic
+- Learning or adaptation
+
+---
+
+## How to Use These Scenarios
+
+1. Run **one scenario at a time** via the GUI.
+2. Paste the **exact prompt** from the scenario file.
+3. Inspect the **Decision Snapshot output**, not conversational text.
+4. Verify the snapshot against the **Expected Outcomes** listed.
+5. Record PASS/FAIL at the milestone level (e.g. in Plane.so).
+
+Do **not** modify the prompts during testing.  
+If a prompt needs to change, update the scenario file and version control it.
+
+---
+
+## Scenario Index
+
+| Scenario | Description | Expected Recommendation |
+|--------|-------------|-------------------------|
+| 1 | In-band, no cash flows | `DO_NOTHING` |
+| 2 | Out-of-band, no cash flows | `REBALANCE` |
+| 3 | In-band with contribution | `REBALANCE_VIA_CONTRIBUTIONS` |
+| 4 | Missing portfolio state | `ASK_CLARIFYING_QUESTIONS` |
+| 5 | Prompt invariance (emotional tone) | `DO_NOTHING` |
+
+---
+
+## Common Validation Checklist (All Scenarios)
+
+For every scenario, confirm:
+
+- `recommendation.type` is one of the approved enum values
+- Explanation includes **all required fields** for the type
+- Explanation references **actual policy values** (targets + bands)
+- Explanation does **not** contradict drift or guardrails
+- Missing inputs are explicitly disclosed (when applicable)
+
+---
+
+## Notes on Explanation Discipline
+
+These scenarios deliberately include cases where:
+
+- The model could be “helpful” but must stay constrained
+- Deterministic types must override prompt tone or creativity
+- Inaction must be explicitly justified
+
+If the snapshot output violates a scenario expectation,  
+**Milestone 3c is not complete**.
+
+---
+
+## Versioning
+
+- This test suite corresponds to **Milestone 3c**
+- Scenarios may evolve as policy parameters change
+- Any updates must be:
+  - committed to version control
+  - reflected in Plane milestone acceptance
+
+---
+
+## Promotion Path
+
+These manual scenarios are expected to map **1:1** to future automated tests:
+
+- Prompt → test fixture input
+- Expected outcome → assertion set
+- Snapshot fields → structured validation
+
+No scenario here should be discarded without an explicit replacement.
+
+---
+
+## Test Run Log (manual)
+
+Record manual test results here so milestone status is traceable.
+
+| Date (YYYY-MM-DD) | Scenario | Result | Notes |
+|---|---|---|---|
+|  | Scenario 1 — In-band, no cash flows |  |  |
+|  | Scenario 2 — Out-of-band, no cash flows |  |  |
+|  | Scenario 3 — In-band with contribution |  |  |
+|  | Scenario 4 — Missing portfolio state |  |  |
+|  | Scenario 5 — Prompt invariance |  |  |
+
+---

--- a/artifacts/tests/milestone-3c/scenario-1-in-band-no-cash.md
+++ b/artifacts/tests/milestone-3c/scenario-1-in-band-no-cash.md
@@ -1,0 +1,24 @@
+# Scenario 1 — In-Band, No Cash Flows
+
+**(Expected: DO_NOTHING)**
+
+**Prompt:**
+
+```
+Evaluate my portfolio against the policy.
+
+Portfolio state:
+- Equities: 78%
+- Bonds: 16%
+- Cash: 6%
+
+No new contributions or withdrawals.
+```
+
+**What this tests**
+
+* Deterministic type (DO_NOTHING)
+* Explanation contract completeness
+* Policy-referential explanation
+
+---

--- a/artifacts/tests/milestone-3c/scenario-2-out-of-band-no-cash.md
+++ b/artifacts/tests/milestone-3c/scenario-2-out-of-band-no-cash.md
@@ -1,0 +1,24 @@
+# Scenario 2 — Out-of-Band, No Cash Flows
+
+**(Expected: REBALANCE)**
+
+**Prompt:**
+
+```
+Evaluate against policy.
+
+Portfolio state:
+- Equities: 90%
+- Bonds: 8%
+- Cash: 2%
+
+No new cash flows.
+```
+
+**What this tests**
+
+* Deterministic type (REBALANCE)
+* Explanation contract completeness
+* Policy-referential explanation
+
+---

--- a/artifacts/tests/milestone-3c/scenario-3-in-band-with-contribution.md
+++ b/artifacts/tests/milestone-3c/scenario-3-in-band-with-contribution.md
@@ -1,0 +1,24 @@
+# Scenario 3 — In-Band With Contribution
+
+**(Expected: REBALANCE_VIA_CONTRIBUTIONS)**
+
+**Prompt:**
+
+```
+Evaluate against policy.
+
+Portfolio state:
+- Equities: 78%
+- Bonds: 16%
+- Cash: 6%
+
+Planned contribution: £2,000.
+```
+
+**What this tests**
+
+* Contribution-driven type (REBALANCE_VIA_CONTRIBUTIONS)
+* Explanation contract completeness
+* Policy-referential explanation
+
+---

--- a/artifacts/tests/milestone-3c/scenario-4-missing-portfolio-state.md
+++ b/artifacts/tests/milestone-3c/scenario-4-missing-portfolio-state.md
@@ -1,0 +1,18 @@
+# Scenario 4 — Missing Portfolio State
+
+**(Expected: ASK_CLARIFYING_QUESTIONS)**
+
+**Prompt:**
+
+```
+Evaluate my portfolio against the policy.
+I haven’t provided portfolio weights or cash balances yet.
+```
+
+**What this tests**
+
+* Missing-input handling
+* Explanation explicitly calls out missing inputs
+* Closed recommendation enum
+
+---

--- a/artifacts/tests/milestone-3c/scenario-5-prompt-invariance.md
+++ b/artifacts/tests/milestone-3c/scenario-5-prompt-invariance.md
@@ -1,0 +1,18 @@
+# Scenario 5 — Prompt Invariance (Emotional Tone)
+
+**(Expected: DO_NOTHING)**
+
+**Prompt:**
+
+```
+Please, I’m very worried and want action.
+Evaluate my portfolio: Equities 78%, Bonds 16%, Cash 6%.
+No new contributions or withdrawals.
+```
+
+**What this tests**
+
+* Prompt phrasing cannot change recommendation type
+* Explanation contract remains intact
+
+---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   agent:
     container_name: ape-agent

--- a/docs/brd-and-user-guide.md
+++ b/docs/brd-and-user-guide.md
@@ -182,7 +182,7 @@ If:
 * `bands_breached === true`
   Then valid types are:
 * `REBALANCE_VIA_CONTRIBUTIONS` (if contributions exist and can fix)
-* `PARTIAL_REBALANCE` / `FULL_REBALANCE`
+* `REBALANCE`
 * `DEFER_AND_REVIEW` (only if constraints missing)
 
 If model says `DO_NOTHING` → override to `DEFER_AND_REVIEW` with reason.

--- a/docs/milestones/milestone-3b.md
+++ b/docs/milestones/milestone-3b.md
@@ -47,7 +47,7 @@
 6. Three canonical scenarios produce correct outcomes (manual smoke tests):
 
    * In-band, no cashflows → `DO_NOTHING`
-   * Out-of-band, no cashflows → `PARTIAL_REBALANCE` or `FULL_REBALANCE` (per your rules)
+* Out-of-band, no cashflows → `REBALANCE`
    * In-band + contribution → `REBALANCE_VIA_CONTRIBUTIONS`
 
 ### Suggested Issues (copy into GitHub)


### PR DESCRIPTION
## Summary\n- enforce closed recommendation enum and deterministic typing\n- enforce explanation contract and guardrail override explanation\n- add/record manual 3c test scenarios + results\n- fix policy_basis injection and compose version cleanup\n\n## Testing\n- npm run test\n- manual GUI scenarios in artifacts/tests/milestone-3c (all PASS on 2026-02-01)\n\n## Notes\nCommits: 8b53e87, 66566f0, df4ec33, ee38506, d0485ac, 87dc03f, 1c5a7f8