### PR TITLE
[M3a] Retrofit Decision Snapshot contract

### DIFF
--- a/agent/lib/domain/decisionSnapshot.ts
+++ b/agent/lib/domain/decisionSnapshot.ts
@@ -14,12 +14,55 @@ export type RecommendationType =
   | "DEFER_AND_REVIEW"
   | "ASK_CLARIFYING_QUESTIONS";
 
+export type OutcomeState =
+  | "RECOMMEND_ACTION"
+  | "RECOMMEND_NO_ACTION"
+  | "CANNOT_DECIDE_MISSING_INPUTS"
+  | "CANNOT_DECIDE_POLICY_GAP"
+  | "ERROR_NONRECOVERABLE";
+
+export type InputObservationSource = "form" | "prompt" | "request" | "policy" | "system";
+
+export interface InputObserved {
+  input_key: string;
+  value: string | number | boolean | null;
+  source: InputObservationSource;
+}
+
+export interface InputMissing {
+  input_key: string;
+  impact: string;
+}
+
+export interface PolicyItemReference {
+  dpq_id: string;
+  ipm_section_heading?: string;
+  ipm_field_key?: string;
+  ipm_clause_id?: string;
+}
+
+export interface SnapshotNotice {
+  code: string;
+  message: string;
+  fields?: string[];
+}
+
 export interface DecisionSnapshot {
   snapshot_id: string;
   snapshot_version: string;
   created_at: string;
 
   project: "AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)";
+
+  outcome_state: OutcomeState;
+
+  inputs_observed: InputObserved[];
+  inputs_missing: InputMissing[];
+
+  policy_items_referenced: PolicyItemReference[];
+
+  warnings: SnapshotNotice[];
+  errors: SnapshotNotice[];
 
   context: {
     user_id: string;

--- a/agent/lib/services/decisionService.ts
+++ b/agent/lib/services/decisionService.ts
@@ -15,9 +15,17 @@
  */
 
 import crypto from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 import type { ChatRequest } from "@/lib/domain/chat";
-import type { DecisionSnapshot, RecommendationType } from "@/lib/domain/decisionSnapshot";
+import type {
+  DecisionSnapshot,
+  OutcomeState,
+  PolicyItemReference,
+  RecommendationType,
+  SnapshotNotice,
+} from "@/lib/domain/decisionSnapshot";
 import type { AuthorityContext } from "@/lib/domain/authority";
 import type { PortfolioStateInput } from "@/lib/domain/portfolioState";
 import type { RiskInputs } from "@/lib/domain/riskInputs";
@@ -35,6 +43,48 @@ import {
 
 const SNAPSHOT_VERSION = "0.3";
 const EPS = 1e-6;
+
+const POLICY_CATALOGUE_PATHS = [
+  path.resolve(process.cwd(), "artifacts", "policy", "default", "decision-principles-catalogue.json"),
+  path.resolve(process.cwd(), "..", "artifacts", "policy", "default", "decision-principles-catalogue.json"),
+];
+
+function loadPolicyCatalogue(): PolicyItemReference[] {
+  for (const candidate of POLICY_CATALOGUE_PATHS) {
+    try {
+      const raw = readFileSync(candidate, "utf-8");
+      const parsed = JSON.parse(raw) as {
+        principles?: Array<{
+          question_id?: string;
+          ipm_mapping?: {
+            ipm_section_heading?: string;
+            ipm_field_key?: string;
+            ipm_clause_id?: string;
+          };
+        }>;
+      };
+      const principles = parsed.principles ?? [];
+      return principles
+        .filter((p) => typeof p.question_id === "string")
+        .map((p) => ({
+          dpq_id: p.question_id as string,
+          ipm_section_heading: p.ipm_mapping?.ipm_section_heading,
+          ipm_field_key: p.ipm_mapping?.ipm_field_key,
+          ipm_clause_id: p.ipm_mapping?.ipm_clause_id,
+        }));
+    } catch {
+      // Continue to next path.
+    }
+  }
+  return [];
+}
+
+const POLICY_ITEMS = loadPolicyCatalogue();
+
+function findPolicyItem(dpqId: string): PolicyItemReference | null {
+  const match = POLICY_ITEMS.find((p) => p.dpq_id === dpqId);
+  return match ?? null;
+}
 
 function extractLastUserMessage(messages: ChatRequest["messages"]): string | null {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
@@ -167,6 +217,76 @@ function describeFormState(state: PortfolioStateInput | undefined): string {
   return `missing: ${missing.join(", ")}`;
 }
 
+function listMissingInputs(state: PortfolioStateInput | null): Array<{ input_key: string; impact: string }> {
+  const missing: Array<{ input_key: string; impact: string }> = [];
+  if (!state) {
+    return [
+      { input_key: "portfolio_state.weights", impact: "Required to compute drift and recommendation." },
+      { input_key: "portfolio_state.cash_flows", impact: "Required to assess cashflow-driven rebalancing." },
+      { input_key: "portfolio_state.total_value", impact: "Required for sizing and validation." },
+    ];
+  }
+
+  if (state.weights.EQUITIES === null || state.weights.BONDS === null || state.weights.CASH === null) {
+    missing.push({
+      input_key: "portfolio_state.weights",
+      impact: "Required to compute drift and recommendation.",
+    });
+  }
+  if (state.cash_flows.pending_contributions_gbp === null || state.cash_flows.pending_withdrawals_gbp === null) {
+    missing.push({
+      input_key: "portfolio_state.cash_flows",
+      impact: "Required to assess cashflow-driven rebalancing.",
+    });
+  }
+  if (state.total_value_gbp === null) {
+    missing.push({
+      input_key: "portfolio_state.total_value",
+      impact: "Required for sizing and validation.",
+    });
+  }
+  return missing;
+}
+
+function outcomeFromRecommendation(type: RecommendationType): OutcomeState {
+  switch (type) {
+    case "DO_NOTHING":
+      return "RECOMMEND_NO_ACTION";
+    case "ASK_CLARIFYING_QUESTIONS":
+      return "CANNOT_DECIDE_MISSING_INPUTS";
+    case "DEFER_AND_REVIEW":
+      return "CANNOT_DECIDE_POLICY_GAP";
+    default:
+      return "RECOMMEND_ACTION";
+  }
+}
+
+function policyItemsForContext(args: {
+  hasAuthorityCheck: boolean;
+  hasDriftCheck: boolean;
+  hasCashflowCheck: boolean;
+  hasRiskCheck: boolean;
+}): PolicyItemReference[] {
+  const refs: PolicyItemReference[] = [];
+  if (args.hasAuthorityCheck) {
+    const item = findPolicyItem("DPQ-001");
+    if (item) refs.push(item);
+  }
+  if (args.hasDriftCheck) {
+    const item = findPolicyItem("DPQ-002");
+    if (item) refs.push(item);
+  }
+  if (args.hasCashflowCheck) {
+    const item = findPolicyItem("DPQ-003");
+    if (item) refs.push(item);
+  }
+  if (args.hasRiskCheck) {
+    const item = findPolicyItem("DPQ-004");
+    if (item) refs.push(item);
+  }
+  return refs;
+}
+
 /**
  * Main entry point for decision generation.
  */
@@ -175,7 +295,108 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
   const createdAt = new Date().toISOString();
 
   if (!Array.isArray(req.messages)) {
-    throw new Error("runDecision: messages must be an array");
+    const errorSnapshot: DecisionSnapshot = {
+      snapshot_id: snapshotId,
+      snapshot_version: SNAPSHOT_VERSION,
+      created_at: createdAt,
+      project: "AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)",
+      outcome_state: "ERROR_NONRECOVERABLE",
+      inputs_observed: [],
+      inputs_missing: [],
+      policy_items_referenced: [],
+      warnings: [],
+      errors: [
+        {
+          code: "INVALID_REQUEST",
+          message: "messages must be an array",
+          fields: ["messages"],
+        },
+      ],
+      context: {
+        user_id: "local",
+        environment: "dev",
+        jurisdiction: "UK",
+        base_currency: "GBP",
+      },
+      inputs: {
+        portfolio_state: {
+          total_value: null,
+          asset_allocation: { EQUITIES: null, BONDS: null, CASH: null },
+          positions_summary: "Not provided.",
+          cash_balance: null,
+        },
+        cash_flows: {
+          pending_contributions: null,
+          pending_withdrawals: null,
+          notes: "Not provided.",
+        },
+        constraints: {
+          liquidity_needs: "Not captured yet.",
+          tax_or_wrapper_constraints: "Not captured yet.",
+          other_constraints: "Not captured yet.",
+        },
+        market_context: {
+          as_of_date: new Date().toISOString().slice(0, 10),
+          notes: "No exceptional market context assumed.",
+        },
+      },
+      governance: {
+        investment_policy: {
+          policy_id: "unknown",
+          policy_version: "unknown",
+          policy_source: "unknown",
+        },
+        explanation_contract: {
+          version: "0.1-default",
+        },
+      },
+      evaluation: {
+        drift_analysis: {
+          target_weights: { EQUITIES: 0, BONDS: 0, CASH: 0 },
+          actual_weights: { EQUITIES: null, BONDS: null, CASH: null },
+          absolute_drift: { EQUITIES: null, BONDS: null, CASH: null },
+          bands_breached: null,
+        },
+        risk_checks: {
+          drawdown_proximity: "Not evaluated.",
+          risk_capacity_breached: null,
+          notes: "Not evaluated.",
+        },
+      },
+      recommendation: {
+        type: "DEFER_AND_REVIEW",
+        summary: "Invalid request; unable to evaluate.",
+        proposed_actions: [],
+        turnover_estimate: {
+          gross_turnover_pct: null,
+          trade_count: null,
+        },
+      },
+      explanation: {
+        decision_summary: "Invalid request; missing messages array.",
+        relevant_portfolio_state: "No portfolio state.",
+        policy_basis: "Policy unavailable due to invalid request.",
+        reasoning_and_tradeoffs: "Cannot evaluate without a valid request payload.",
+        uncertainty_and_confidence: "High uncertainty due to invalid request.",
+        next_review_or_trigger: "Fix request payload and retry.",
+      },
+      user_acknowledgement: {
+        decision: "DEFER",
+        acknowledged_at: null,
+        user_notes: "Invalid request payload.",
+      },
+      outcome: {
+        implemented: null,
+        implementation_notes: null,
+        review_date: null,
+        observed_effects: null,
+      },
+      audit: {
+        logic_version: SNAPSHOT_VERSION,
+        notes: "Invalid request; snapshot generated for error reporting.",
+      },
+    };
+    return { snapshot: errorSnapshot };
   }
 
   /**
@@ -265,6 +486,13 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
 
   const expectedRecommendationType: RecommendationType =
     preflightOverride ?? baseRecommendationType;
+
+  const policyItems = policyItemsForContext({
+    hasAuthorityCheck: true,
+    hasDriftCheck: !!driftResult,
+    hasCashflowCheck: hasCashFlows,
+    hasRiskCheck: true,
+  });
 
   /**
    * ------------------------------------------------------------------
@@ -530,12 +758,86 @@ Portfolio state has NOT been provided.
    * Build Decision Snapshot
    * ------------------------------------------------------------------
    */
+  const missingInputs = listMissingInputs(state);
+  const outcomeState: OutcomeState =
+    missingInputs.length > 0 && (!state || expectedRecommendationType === "ASK_CLARIFYING_QUESTIONS")
+      ? "CANNOT_DECIDE_MISSING_INPUTS"
+      : outcomeFromRecommendation(finalModel.recommendation_type);
+  const warnings: SnapshotNotice[] = [];
+  const errors: SnapshotNotice[] = [];
+
+  if (outcomeState === "CANNOT_DECIDE_MISSING_INPUTS" && missingInputs.length === 0) {
+    warnings.push({
+      code: "MISSING_INPUTS_UNSPECIFIED",
+      message: "Missing inputs expected but none were recorded.",
+    });
+  }
+
+  if (riskEval.status === "POLICY_MISSING") {
+    warnings.push({
+      code: "POLICY_GAP_RISK_GUARDRAILS",
+      message: "Risk guardrails missing or invalid in policy.",
+      fields: ["policy.risk_guardrails"],
+    });
+  }
+
+  if (authorityViolation) {
+    warnings.push({
+      code: "AUTHORITY_VIOLATION",
+      message: authorityViolation,
+      fields: ["authority.actor_role", "authority.decision_intent"],
+    });
+  }
+
+  const inputsObserved = [
+    ...(state
+      ? [
+          { input_key: "portfolio_state.weights", value: "provided", source: "form" as const },
+          { input_key: "portfolio_state.cash_flows", value: "provided", source: "form" as const },
+          { input_key: "portfolio_state.total_value", value: state.total_value_gbp, source: "form" as const },
+        ]
+      : []),
+    ...(parsedState && !state
+      ? [
+          { input_key: "portfolio_state.weights", value: "provided", source: "prompt" as const },
+          { input_key: "portfolio_state.cash_flows", value: "provided", source: "prompt" as const },
+        ]
+      : []),
+    ...(riskInputs
+      ? [
+          {
+            input_key: "risk_inputs.rolling_12m_drawdown_pct",
+            value: riskInputs.rolling_12m_drawdown_pct ?? null,
+            source: "request" as const,
+          },
+          {
+            input_key: "risk_inputs.risk_capacity_breached",
+            value: riskInputs.risk_capacity_breached ?? null,
+            source: "request" as const,
+          },
+        ]
+      : []),
+    ...(authority
+      ? [
+          { input_key: "authority.actor_role", value: authority.actor_role, source: "request" as const },
+          { input_key: "authority.decision_intent", value: authority.decision_intent, source: "request" as const },
+        ]
+      : []),
+  ];
+
   const snapshot: DecisionSnapshot = {
     snapshot_id: snapshotId,
     snapshot_version: SNAPSHOT_VERSION,
     created_at: createdAt,
 
     project: "AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)",
+
+    outcome_state: outcomeState,
+    inputs_observed: inputsObserved,
+    inputs_missing: outcomeState === "CANNOT_DECIDE_MISSING_INPUTS" ? missingInputs : [],
+    policy_items_referenced: policyItems,
+    warnings,
+    errors,
 
     context: {
       user_id: "local",
@@ -656,6 +958,13 @@ Portfolio state has NOT been provided.
         .join(" "),
     },
   };
+
+  if (outcomeState === "CANNOT_DECIDE_POLICY_GAP" && warnings.length === 0) {
+    warnings.push({
+      code: "POLICY_GAP",
+      message: "Decision deferred due to policy gap or guardrail override.",
+    });
+  }
 
   return { snapshot };
 }

--- a/agent/lib/services/decisionSnapshotContract.test.ts
+++ b/agent/lib/services/decisionSnapshotContract.test.ts
@@ -1,0 +1,151 @@
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+
+import { runDecision } from "@/lib/services/decisionService";
+import type { DecisionSnapshot } from "@/lib/domain/decisionSnapshot";
+
+vi.mock("@/lib/infra/policyLoader", () => ({
+  loadPolicy: () => ({
+    policy_id: "ape-policy",
+    policy_version: "0.1-test",
+    source: "test",
+    jurisdiction: "UK",
+    strategic_asset_allocation: {
+      base_currency: "GBP",
+      target_weights: {
+        EQUITIES: 0.8,
+        BONDS: 0.15,
+        CASH: 0.05,
+      },
+    },
+    risk_guardrails: {
+      max_rolling_12m_drawdown_pct: 0.2,
+      risk_capacity_rule: "RISK_CAPACITY_OVERRIDES_TOLERANCE",
+    },
+    rebalancing_policy: {
+      absolute_bands: {
+        EQUITIES: 0.05,
+        BONDS: 0.04,
+        CASH: 0.02,
+      },
+    },
+    constraints: {
+      prohibited_actions: ["LEVERAGE", "MARGIN", "MARKET_TIMING"],
+    },
+  }),
+}));
+
+vi.mock("@/lib/infra/mastra", () => ({
+  generateAssistantReply: vi.fn(async () =>
+    JSON.stringify({
+      recommendation_type: "DO_NOTHING",
+      recommendation_summary: "Policy-aligned recommendation.",
+      proposed_actions: [],
+      explanation: {
+        decision_summary: "Decision follows the investment policy guardrails.",
+        relevant_portfolio_state: "Inputs were parsed from the request.",
+        policy_basis:
+          "Targets: equities 0.8, bonds 0.15, cash 0.05. Bands: equities 0.05, bonds 0.04, cash 0.02. Policy ape-policy v0.1-test (test).",
+        reasoning_and_tradeoffs: "Guardrails prevent unnecessary action.",
+        uncertainty_and_confidence: "High confidence given deterministic inputs.",
+        next_review_or_trigger: "Review if inputs or cash flows change.",
+      },
+    })
+  ),
+}));
+
+type SnapshotWithOutcome = DecisionSnapshot & { outcome_state: string };
+
+function assertSnapshotContract(snapshot: DecisionSnapshot): void {
+  if (!snapshot.outcome_state) {
+    throw new Error("snapshot.outcome_state is required");
+  }
+  if (!Array.isArray(snapshot.warnings)) {
+    throw new Error("snapshot.warnings must be an array");
+  }
+  if (!Array.isArray(snapshot.errors)) {
+    throw new Error("snapshot.errors must be an array");
+  }
+  for (const warn of snapshot.warnings) {
+    if (!warn || typeof warn.code !== "string" || typeof warn.message !== "string") {
+      throw new Error("snapshot.warnings must contain structured entries");
+    }
+  }
+  for (const err of snapshot.errors) {
+    if (!err || typeof err.code !== "string" || typeof err.message !== "string") {
+      throw new Error("snapshot.errors must contain structured entries");
+    }
+  }
+}
+
+describe("Decision Snapshot contract (M3a)", () => {
+  it("always returns a snapshot with outcome_state", async () => {
+    const result = await runDecision({
+      messages: [{ role: "user", content: "Evaluate my portfolio." }],
+    });
+    expect(result.snapshot.outcome_state).toBeTruthy();
+  });
+
+  it("missing inputs outcome includes inputs_missing entries", async () => {
+    const result = await runDecision({
+      messages: [{ role: "user", content: "Evaluate my portfolio." }],
+    });
+
+    expect(result.snapshot.outcome_state).toBe("CANNOT_DECIDE_MISSING_INPUTS");
+    expect(result.snapshot.inputs_missing.length).toBeGreaterThan(0);
+    for (const item of result.snapshot.inputs_missing) {
+      expect(item.input_key).toBeTruthy();
+      expect(item.impact).toBeTruthy();
+    }
+  });
+
+  it("policy_items_referenced includes at least one DPQ id on a normal path", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio. Portfolio state: Equities 78%, Bonds 16%, Cash 6%. No cash flows.",
+        },
+      ],
+      risk_inputs: { rolling_12m_drawdown_pct: 0.1, risk_capacity_breached: false },
+    });
+
+    expect(result.snapshot.policy_items_referenced.length).toBeGreaterThan(0);
+    expect(result.snapshot.policy_items_referenced[0]?.dpq_id).toMatch(/^DPQ-\d{3}$/);
+  });
+
+  it("warnings/errors are arrays of structured objects", async () => {
+    const result = await runDecision({
+      messages: [{ role: "user", content: "Evaluate my portfolio." }],
+    });
+
+    assertSnapshotContract(result.snapshot);
+  });
+
+  it("golden snapshot exists and includes required fields", () => {
+    const repoRoot = path.resolve(process.cwd(), "..");
+    const snapshotPath = path.join(
+      repoRoot,
+      "artifacts",
+      "reference",
+      "milestone-3a",
+      "golden_snapshot.in_band.no_cashflows.json"
+    );
+    const raw = readFileSync(snapshotPath, "utf-8");
+    const snapshot = JSON.parse(raw) as SnapshotWithOutcome;
+
+    expect(snapshot.outcome_state).toBe("RECOMMEND_NO_ACTION");
+    expect(Array.isArray(snapshot.inputs_observed)).toBe(true);
+    expect(Array.isArray(snapshot.inputs_missing)).toBe(true);
+    expect(Array.isArray(snapshot.policy_items_referenced)).toBe(true);
+    expect(Array.isArray(snapshot.warnings)).toBe(true);
+    expect(Array.isArray(snapshot.errors)).toBe(true);
+  });
+
+  it("fails validation when outcome_state is missing", () => {
+    const badSnapshot = { warnings: [], errors: [] } as unknown as DecisionSnapshot;
+    expect(() => assertSnapshotContract(badSnapshot)).toThrow("snapshot.outcome_state is required");
+  });
+});

--- a/artifacts/reference/milestone-3a/golden_snapshot.in_band.no_cashflows.json
+++ b/artifacts/reference/milestone-3a/golden_snapshot.in_band.no_cashflows.json
@@ -1,0 +1,129 @@
+{
+  "snapshot_id": "00000000-0000-0000-0000-000000000000",
+  "snapshot_version": "0.3",
+  "created_at": "2026-02-08T00:00:00Z",
+  "project": "AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)",
+  "outcome_state": "RECOMMEND_NO_ACTION",
+  "inputs_observed": [
+    {
+      "input_key": "portfolio_state.weights",
+      "value": "provided",
+      "source": "form"
+    },
+    {
+      "input_key": "portfolio_state.cash_flows",
+      "value": "provided",
+      "source": "form"
+    }
+  ],
+  "inputs_missing": [],
+  "policy_items_referenced": [
+    {
+      "dpq_id": "DPQ-002",
+      "ipm_section_heading": "Rebalancing Philosophy",
+      "ipm_field_key": "rebalancing.philosophy",
+      "ipm_clause_id": "IPM-RBP-001"
+    }
+  ],
+  "warnings": [],
+  "errors": [],
+  "context": {
+    "user_id": "sample",
+    "environment": "reference",
+    "jurisdiction": "UK",
+    "base_currency": "GBP"
+  },
+  "inputs": {
+    "portfolio_state": {
+      "total_value": 100000,
+      "asset_allocation": {
+        "EQUITIES": 0.78,
+        "BONDS": 0.16,
+        "CASH": 0.06
+      },
+      "positions_summary": "Structured portfolio state provided (manual input).",
+      "cash_balance": null
+    },
+    "cash_flows": {
+      "pending_contributions": 0,
+      "pending_withdrawals": 0,
+      "notes": "No cash flows provided."
+    },
+    "constraints": {
+      "liquidity_needs": "Not captured yet.",
+      "tax_or_wrapper_constraints": "Not captured yet.",
+      "other_constraints": "Not captured yet."
+    },
+    "market_context": {
+      "as_of_date": "2026-02-08",
+      "notes": "No exceptional market context assumed."
+    }
+  },
+  "governance": {
+    "investment_policy": {
+      "policy_id": "ape-policy",
+      "policy_version": "0.1-default",
+      "policy_source": "default"
+    },
+    "explanation_contract": {
+      "version": "0.1-default"
+    }
+  },
+  "evaluation": {
+    "drift_analysis": {
+      "target_weights": {
+        "EQUITIES": 0.8,
+        "BONDS": 0.15,
+        "CASH": 0.05
+      },
+      "actual_weights": {
+        "EQUITIES": 0.78,
+        "BONDS": 0.16,
+        "CASH": 0.06
+      },
+      "absolute_drift": {
+        "EQUITIES": -0.02,
+        "BONDS": 0.01,
+        "CASH": 0.01
+      },
+      "bands_breached": false
+    },
+    "risk_checks": {
+      "drawdown_proximity": "Not evaluated.",
+      "risk_capacity_breached": false,
+      "notes": "Risk guardrails satisfied."
+    }
+  },
+  "recommendation": {
+    "type": "DO_NOTHING",
+    "summary": "No action required; portfolio is within policy rebalancing bands.",
+    "proposed_actions": [],
+    "turnover_estimate": {
+      "gross_turnover_pct": 0,
+      "trade_count": 0
+    }
+  },
+  "explanation": {
+    "decision_summary": "Portfolio is within policy bands and no action is required.",
+    "relevant_portfolio_state": "Weights are within target bands with no cash flows.",
+    "policy_basis": "Policy targets and bands were applied.",
+    "reasoning_and_tradeoffs": "Rebalancing is unnecessary without a band breach.",
+    "uncertainty_and_confidence": "High confidence given deterministic inputs.",
+    "next_review_or_trigger": "Review at next scheduled check or if inputs change."
+  },
+  "user_acknowledgement": {
+    "decision": "DEFER",
+    "user_notes": "Reference snapshot.",
+    "acknowledged_at": null
+  },
+  "outcome": {
+    "implemented": null,
+    "implementation_notes": null,
+    "review_date": null,
+    "observed_effects": null
+  },
+  "audit": {
+    "logic_version": "0.3",
+    "notes": "Reference snapshot for Milestone 3a."
+  }
+}


### PR DESCRIPTION
Purpose:
Complete Milestone 3a by hardening the Decision Snapshot contract with explicit
outcome states, missing-input evidence, DPQ/IPM policy provenance, and structured
warnings/errors.

Scope in:
- DecisionSnapshot contract fields (M3a only)
- Snapshot population in decisionService
- Golden reference snapshot
- Deterministic contract tests

Scope out:
- policy_applied (M3b)
- expanded guardrails and coherence rules (M3c)
- any decision logic changes beyond contract fulfilment

Evidence:
- agent/lib/domain/decisionSnapshot.ts
- agent/lib/services/decisionService.ts
- agent/lib/services/decisionSnapshotContract.test.ts
- artifacts/reference/milestone-3a/golden_snapshot.in_band.no_cashflows.json

Tests:
- cd agent && npm test
