### PR TITLE
[M3a] Record snapshot contract retrofit in changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,5 +92,34 @@
 
 ---
 
+## 2026-02-07 — Iteration M3a (Snapshot Contract Retrofit & Observability Fields)
+### Added
+- Decision Snapshot contract fields: `outcome_state`, `inputs_observed`, `inputs_missing`, `policy_items_referenced`, `warnings[]`, `errors[]` (structured).
+- Golden snapshot artifact for in-band / no-cashflows scenario under `artifacts/reference/milestone-3a/`.
+- Contract validation tests including negative validation coverage.
+
+### Changed
+- Decision service now returns snapshot-shaped error responses for invalid requests.
+- Missing or incomplete inputs produce explicit missing-input outcomes rather than silent failure.
+
+### Fixed
+- N/A
+
+### Removed
+- N/A
+
+### Data / Schema
+- Decision Snapshot contract expanded to include explicit outcome state, input provenance, policy references, and structured warnings/errors.
+
+### Risks / Follow-ups
+- Policy application details (`policy_applied`) and expanded guardrails remain out of scope for M3a.
+
+### Manual regression checks (quick)
+- [ ] Invalid request returns snapshot with populated `outcome_state` and structured `errors[]`.
+- [ ] Missing inputs populate `inputs_missing[]` and yield a safe missing-input outcome.
+- [ ] Normal in-band path includes at least one `policy_items_referenced` DPQ id.
+
+---
+
 ## Milestone 3c Marker
 Backfilled documentation is complete through Milestone 3c.

--- a/docs/reference/tests/README.md
+++ b/docs/reference/tests/README.md
@@ -27,3 +27,10 @@ This folder contains manual test scenarios used to validate milestone behavior. 
 ## Which Milestone Is Current
 
 If multiple milestone sets exist, prefer the newest milestone folder (highest number/letter) unless a specific test plan says otherwise.
+
+## Available Milestone Folders
+
+- `docs/reference/tests/milestone-1/`
+- `docs/reference/tests/milestone-3a/`
+- `docs/reference/tests/milestone-3b/`
+- `docs/reference/tests/milestone-3c/`

--- a/docs/reference/tests/milestone-3a/README.md
+++ b/docs/reference/tests/milestone-3a/README.md
@@ -1,0 +1,102 @@
+---
+> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+>
+> This document is supporting material and is **not** a source of truth.
+> The authoritative docs are:
+> - `docs/ARCHITECTURE.md`
+> - `docs/CHANGELOG.md`
+> - `docs/decisions/` (ADR-lite)
+>
+> If this document conflicts with code or ADRs, treat this document as outdated.
+---
+# Milestone 3a — Manual Test Scenarios  
+**Decision Snapshot Foundation**
+
+---
+
+## Purpose
+
+This folder contains **manual acceptance test scenarios** for **Milestone 3a** of the  
+**AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)**.
+
+Milestone 3a focuses on ensuring that:
+- A Decision Snapshot is always produced
+- Outcome states are explicit and consistent
+- Missing inputs are surfaced with impact
+- Policy provenance is captured with DPQ references
+- Warnings and errors are structured (not concatenated strings)
+
+---
+
+## Scope (What Is Tested)
+
+Included in scope:
+- Snapshot creation on every request
+- Missing-input handling and evidence
+- Policy provenance fields
+- Structured warnings/errors
+
+Explicitly out of scope:
+- policy_applied (Milestone 3b)
+- expanded guardrails and coherence rules (Milestone 3c)
+- portfolio optimization or execution logic
+
+---
+
+## How to Use These Scenarios
+
+1. Run **one scenario at a time**.
+2. Use the **PowerShell API call** provided in each scenario file.
+3. Inspect the **Decision Snapshot output**, not conversational text.
+4. Verify the snapshot against the **Expected Outcomes** listed.
+5. Record PASS/FAIL at the milestone level (e.g. in Plane.so).
+
+Do **not** modify the prompts during testing.  
+If a prompt needs to change, update the scenario file and version control it.
+
+---
+
+## Scenario Index
+
+| Scenario | Description | Expected Outcome State |
+|--------|-------------|------------------------|
+| 1 | Missing portfolio state | `CANNOT_DECIDE_MISSING_INPUTS` |
+| 2 | In-band, no cash flows | `RECOMMEND_NO_ACTION` |
+| 3 | Policy provenance check | `RECOMMEND_NO_ACTION` |
+
+---
+
+## Common Validation Checklist (All Scenarios)
+
+For every scenario, confirm:
+- A **Decision Snapshot** is produced (no silent failure)
+- `snapshot_id`, `created_at`, and `snapshot_version` are populated
+- `outcome_state` is present and matches the scenario expectation
+- `inputs_observed` is present and structured
+- `inputs_missing` is present (empty allowed only if outcome is not missing-input)
+- `policy_items_referenced` includes DPQ IDs when a decision is made
+- `warnings` and `errors` are arrays of structured objects
+
+---
+
+## Versioning
+
+- This test suite corresponds to **Milestone 3a**
+- Scenarios may evolve as policy parameters change
+- Any updates must be:
+- committed to version control
+- reflected in Plane milestone acceptance
+
+---
+
+## Test Run Log (manual)
+
+Record manual test results here so milestone status is traceable.
+
+| Date (YYYY-MM-DD) | Scenario | Result | Notes |
+|---|---|---|---|
+| 2026-02-08 | Scenario 1 — Missing portfolio state |  |  |
+| 2026-02-08 | Scenario 2 — In-band, no cash flows |  |  |
+| 2026-02-08 | Scenario 3 — Policy provenance check |  |  |
+
+---

--- a/docs/reference/tests/milestone-3a/SCENARIO_1_MISSING_STATE.md
+++ b/docs/reference/tests/milestone-3a/SCENARIO_1_MISSING_STATE.md
@@ -1,0 +1,50 @@
+---
+> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+>
+> This document is supporting material and is **not** a source of truth.
+> The authoritative docs are:
+> - `docs/ARCHITECTURE.md`
+> - `docs/CHANGELOG.md`
+> - `docs/decisions/` (ADR-lite)
+>
+> If this document conflicts with code or ADRs, treat this document as outdated.
+---
+# Scenario 1 — Missing Portfolio State
+
+**(Expected: CANNOT_DECIDE_MISSING_INPUTS)**
+
+**Prompt:**
+
+```
+Evaluate my portfolio against the current investment policy.
+
+I have not provided my current portfolio weights or cash balances yet.
+Please proceed according to policy and generate a decision snapshot.
+```
+
+**API Call (PowerShell):**
+
+```powershell
+$body = @{ 
+  messages = @(
+    @{ role = "user"; content = "Evaluate my portfolio against the current investment policy. I have not provided my current portfolio weights or cash balances yet. Please proceed according to policy and generate a decision snapshot." }
+  )
+} | ConvertTo-Json -Depth 10
+
+Invoke-RestMethod -Method Post -Uri "http://localhost:3000/api/chat" -ContentType "application/json" -Body $body
+```
+
+**Expected Outcomes:**
+
+- `snapshot` is present
+- `snapshot.outcome_state` is `CANNOT_DECIDE_MISSING_INPUTS`
+- `snapshot.inputs_missing` is non-empty and each item includes `input_key` and `impact`
+- `snapshot.warnings` and `snapshot.errors` are arrays of structured objects
+
+**What this tests**
+
+* Missing-input handling is explicit
+* No silent failure when required data is absent
+* Outcome state is deterministic
+
+---

--- a/docs/reference/tests/milestone-3a/SCENARIO_2_IN_BAND.md
+++ b/docs/reference/tests/milestone-3a/SCENARIO_2_IN_BAND.md
@@ -1,0 +1,62 @@
+---
+> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+>
+> This document is supporting material and is **not** a source of truth.
+> The authoritative docs are:
+> - `docs/ARCHITECTURE.md`
+> - `docs/CHANGELOG.md`
+> - `docs/decisions/` (ADR-lite)
+>
+> If this document conflicts with code or ADRs, treat this document as outdated.
+---
+# Scenario 2 — In-Band Drift, No Cash Flows
+
+**(Expected: RECOMMEND_NO_ACTION)**
+
+**Prompt:**
+
+```
+Evaluate my portfolio against the current investment policy.
+
+Portfolio state:
+- As of date: 2026-02-07
+- Total value: £100,000
+- Weights: EQUITIES 78%, BONDS 16%, CASH 6%
+- No pending contributions or withdrawals
+
+Generate a decision snapshot and recommendation.
+```
+
+**API Call (PowerShell):**
+
+```powershell
+$body = @{ 
+  messages = @(
+    @{ role = "user"; content = "Evaluate my portfolio against the current investment policy. Portfolio state: As of date 2026-02-07. Total value: £100,000. Weights: EQUITIES 78%, BONDS 16%, CASH 6%. No pending contributions or withdrawals. Generate a decision snapshot and recommendation." }
+  )
+  portfolio_state = @{ 
+    as_of_date = "2026-02-07"
+    total_value_gbp = 100000
+    weights = @{ EQUITIES = 0.78; BONDS = 0.16; CASH = 0.06 }
+    cash_flows = @{ pending_contributions_gbp = 0; pending_withdrawals_gbp = 0 }
+  }
+} | ConvertTo-Json -Depth 10
+
+Invoke-RestMethod -Method Post -Uri "http://localhost:3000/api/chat" -ContentType "application/json" -Body $body
+```
+
+**Expected Outcomes:**
+
+- `snapshot.outcome_state` is `RECOMMEND_NO_ACTION`
+- `snapshot.inputs_observed` includes portfolio state values
+- `snapshot.inputs_missing` is empty or not present
+- `snapshot.policy_items_referenced` includes at least one `dpq_id`
+- `snapshot.warnings` and `snapshot.errors` are arrays
+
+**What this tests**
+
+* Snapshot created on a normal path
+* Outcome states are explicit
+* Policy provenance is recorded
+
+---

--- a/docs/reference/tests/milestone-3a/SCENARIO_3_POLICY_PROVENANCE.md
+++ b/docs/reference/tests/milestone-3a/SCENARIO_3_POLICY_PROVENANCE.md
@@ -1,0 +1,60 @@
+---
+> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+>
+> This document is supporting material and is **not** a source of truth.
+> The authoritative docs are:
+> - `docs/ARCHITECTURE.md`
+> - `docs/CHANGELOG.md`
+> - `docs/decisions/` (ADR-lite)
+>
+> If this document conflicts with code or ADRs, treat this document as outdated.
+---
+# Scenario 3 — Policy Provenance Check
+
+**(Expected: RECOMMEND_NO_ACTION)**
+
+**Prompt:**
+
+```
+Evaluate my portfolio against the current investment policy and include policy provenance.
+
+Portfolio state:
+- As of date: 2026-02-07
+- Total value: £200,000
+- Weights: EQUITIES 75%, BONDS 20%, CASH 5%
+- No pending contributions or withdrawals
+
+Return a decision snapshot with referenced policy items.
+```
+
+**API Call (PowerShell):**
+
+```powershell
+$body = @{ 
+  messages = @(
+    @{ role = "user"; content = "Evaluate my portfolio against the current investment policy and include policy provenance. Portfolio state: As of date 2026-02-07. Total value: £200,000. Weights: EQUITIES 75%, BONDS 20%, CASH 5%. No pending contributions or withdrawals. Return a decision snapshot with referenced policy items." }
+  )
+  portfolio_state = @{ 
+    as_of_date = "2026-02-07"
+    total_value_gbp = 200000
+    weights = @{ EQUITIES = 0.75; BONDS = 0.20; CASH = 0.05 }
+    cash_flows = @{ pending_contributions_gbp = 0; pending_withdrawals_gbp = 0 }
+  }
+} | ConvertTo-Json -Depth 10
+
+Invoke-RestMethod -Method Post -Uri "http://localhost:3000/api/chat" -ContentType "application/json" -Body $body
+```
+
+**Expected Outcomes:**
+
+- `snapshot.outcome_state` is `RECOMMEND_NO_ACTION`
+- `snapshot.policy_items_referenced` includes one or more `dpq_id` values
+- `snapshot.policy_items_referenced` entries include IPM fields when available
+- `snapshot.warnings` and `snapshot.errors` are arrays (empty allowed)
+
+**What this tests**
+
+* Policy provenance is recorded in a structured, auditable format
+* DPQ references are stable IDs, not free text
+
+---


### PR DESCRIPTION
**Purpose**
Record the completed M3a snapshot contract retrofit in the changelog.

**Scope in**
- Changelog entry for M3a (snapshot contract retrofit)

**Scope out**
- No code or policy changes
- No ADR or architecture updates

**Evidence**
- docs/CHANGELOG.md

**Tests**
- cd agent && npm test
