### PR TITLE
Milestone 3b: “Show your work” evaluation + drift + contradiction rejection

### DIFF
--- a/agent/lib/domain/decisionSnapshot.ts
+++ b/agent/lib/domain/decisionSnapshot.ts
@@ -47,6 +47,37 @@ export interface SnapshotNotice {
   fields?: string[];
 }
 
+export type PolicyAppliedStatus = "applied" | "not_applied" | "partial" | "blocked";
+
+export interface PolicyAppliedEvaluation {
+  targets: { EQUITIES: number; BONDS: number; CASH: number } | null;
+  bands: { EQUITIES: number; BONDS: number; CASH: number } | null;
+  risk_guardrails_used: string[];
+  evaluated_policies: string[];
+  skipped_policies: Array<{ dpq_id: string; reason: string }>;
+  status: PolicyAppliedStatus;
+  reason_codes: string[];
+  blocking_inputs?: string[];
+}
+
+export type CorrectnessStatus = "pass" | "fail" | "indeterminate";
+
+export interface CorrectnessEvaluation {
+  status: CorrectnessStatus;
+  checks_run: string[];
+  failed_checks?: string[];
+}
+
+export type DriftStatus = "computed" | "not_applicable" | "cannot_compute";
+
+export interface DriftEvaluation {
+  status: DriftStatus;
+  target_weights?: { EQUITIES: number; BONDS: number; CASH: number };
+  actual_weights?: { EQUITIES: number | null; BONDS: number | null; CASH: number | null };
+  absolute_drift?: { EQUITIES: number | null; BONDS: number | null; CASH: number | null };
+  bands_breached?: boolean | null;
+}
+
 export interface DecisionSnapshot {
   snapshot_id: string;
   snapshot_version: string;
@@ -110,6 +141,9 @@ export interface DecisionSnapshot {
   };
 
   evaluation: {
+    policy_applied: PolicyAppliedEvaluation;
+    correctness: CorrectnessEvaluation;
+    drift: DriftEvaluation;
     drift_analysis: {
       target_weights: { EQUITIES: number; BONDS: number; CASH: number };
       actual_weights: { EQUITIES: number | null; BONDS: number | null; CASH: number | null };

--- a/agent/lib/services/decisionService.ts
+++ b/agent/lib/services/decisionService.ts
@@ -15,8 +15,6 @@
  */
 
 import crypto from "node:crypto";
-import { readFileSync } from "node:fs";
-import path from "node:path";
 
 import type { ChatRequest } from "@/lib/domain/chat";
 import type {
@@ -44,42 +42,27 @@ import {
 const SNAPSHOT_VERSION = "0.3";
 const EPS = 1e-6;
 
-const POLICY_CATALOGUE_PATHS = [
-  path.resolve(process.cwd(), "artifacts", "policy", "default", "decision-principles-catalogue.json"),
-  path.resolve(process.cwd(), "..", "artifacts", "policy", "default", "decision-principles-catalogue.json"),
+const DPQ_AUTHORITY = "DPQ-001";
+const DPQ_DRIFT = "DPQ-002";
+const DPQ_CASHFLOW = "DPQ-003";
+const DPQ_RISK = "DPQ-004";
+
+const POLICY_ITEMS: PolicyItemReference[] = [
+  { dpq_id: DPQ_AUTHORITY },
+  { dpq_id: DPQ_DRIFT },
+  { dpq_id: DPQ_CASHFLOW },
+  { dpq_id: DPQ_RISK },
 ];
 
-function loadPolicyCatalogue(): PolicyItemReference[] {
-  for (const candidate of POLICY_CATALOGUE_PATHS) {
-    try {
-      const raw = readFileSync(candidate, "utf-8");
-      const parsed = JSON.parse(raw) as {
-        principles?: Array<{
-          question_id?: string;
-          ipm_mapping?: {
-            ipm_section_heading?: string;
-            ipm_field_key?: string;
-            ipm_clause_id?: string;
-          };
-        }>;
-      };
-      const principles = parsed.principles ?? [];
-      return principles
-        .filter((p) => typeof p.question_id === "string")
-        .map((p) => ({
-          dpq_id: p.question_id as string,
-          ipm_section_heading: p.ipm_mapping?.ipm_section_heading,
-          ipm_field_key: p.ipm_mapping?.ipm_field_key,
-          ipm_clause_id: p.ipm_mapping?.ipm_clause_id,
-        }));
-    } catch {
-      // Continue to next path.
-    }
-  }
-  return [];
-}
-
-const POLICY_ITEMS = loadPolicyCatalogue();
+const REASON_CODES = {
+  MISSING_INPUTS: "MISSING_INPUTS",
+  DRIFT_CANNOT_COMPUTE: "DRIFT_CANNOT_COMPUTE",
+  CONTRADICTION_DETECTED: "CONTRADICTION_DETECTED",
+  SKIPPED_NOT_APPLICABLE: "SKIPPED_NOT_APPLICABLE",
+  POLICY_APPLIED: "POLICY_APPLIED",
+  PARTIAL_APPLY: "PARTIAL_APPLY",
+  BLOCKED: "BLOCKED",
+} as const;
 
 function findPolicyItem(dpqId: string): PolicyItemReference | null {
   const match = POLICY_ITEMS.find((p) => p.dpq_id === dpqId);
@@ -217,17 +200,25 @@ function describeFormState(state: PortfolioStateInput | undefined): string {
   return `missing: ${missing.join(", ")}`;
 }
 
-function listMissingInputs(state: PortfolioStateInput | null): Array<{ input_key: string; impact: string }> {
+function listMissingInputs(
+  state: PortfolioStateInput | null,
+  hasPortfolioStateProvided: boolean
+): Array<{ input_key: string; impact: string }> {
   const missing: Array<{ input_key: string; impact: string }> = [];
   if (!state) {
     return [
-      { input_key: "portfolio_state.weights", impact: "Required to compute drift and recommendation." },
+      ...(hasPortfolioStateProvided
+        ? []
+        : [{ input_key: "portfolio_state.weights", impact: "Required to compute drift and recommendation." }]),
       { input_key: "portfolio_state.cash_flows", impact: "Required to assess cashflow-driven rebalancing." },
       { input_key: "portfolio_state.total_value", impact: "Required for sizing and validation." },
     ];
   }
 
-  if (state.weights.EQUITIES === null || state.weights.BONDS === null || state.weights.CASH === null) {
+  if (
+    !hasPortfolioStateProvided &&
+    (state.weights.EQUITIES === null || state.weights.BONDS === null || state.weights.CASH === null)
+  ) {
     missing.push({
       input_key: "portfolio_state.weights",
       impact: "Required to compute drift and recommendation.",
@@ -269,22 +260,149 @@ function policyItemsForContext(args: {
 }): PolicyItemReference[] {
   const refs: PolicyItemReference[] = [];
   if (args.hasAuthorityCheck) {
-    const item = findPolicyItem("DPQ-001");
+    const item = findPolicyItem(DPQ_AUTHORITY);
     if (item) refs.push(item);
   }
   if (args.hasDriftCheck) {
-    const item = findPolicyItem("DPQ-002");
+    const item = findPolicyItem(DPQ_DRIFT);
     if (item) refs.push(item);
   }
   if (args.hasCashflowCheck) {
-    const item = findPolicyItem("DPQ-003");
+    const item = findPolicyItem(DPQ_CASHFLOW);
     if (item) refs.push(item);
   }
   if (args.hasRiskCheck) {
-    const item = findPolicyItem("DPQ-004");
+    const item = findPolicyItem(DPQ_RISK);
     if (item) refs.push(item);
   }
   return refs;
+}
+
+function detectContradiction(args: {
+  expected: RecommendationType;
+  model: RecommendationType;
+  hasState: boolean;
+  driftResult: ReturnType<typeof computeDrift> | null;
+}): string | null {
+  if (!args.hasState || !args.driftResult) return null;
+  if (args.model !== args.expected) {
+    return `Model recommendation ${args.model} contradicts deterministic expectation ${args.expected}.`;
+  }
+  return null;
+}
+
+function buildDriftEvaluation(args: {
+  hasPortfolioStateProvided: boolean;
+  driftResult: ReturnType<typeof computeDrift> | null;
+  policy: PolicyJson;
+}) {
+  if (args.driftResult) {
+    return {
+      status: "computed" as const,
+      target_weights: {
+        EQUITIES: args.policy.strategic_asset_allocation.target_weights.EQUITIES,
+        BONDS: args.policy.strategic_asset_allocation.target_weights.BONDS,
+        CASH: args.policy.strategic_asset_allocation.target_weights.CASH,
+      },
+      actual_weights: {
+        EQUITIES: args.driftResult.actual_weights.EQUITIES,
+        BONDS: args.driftResult.actual_weights.BONDS,
+        CASH: args.driftResult.actual_weights.CASH,
+      },
+      absolute_drift: {
+        EQUITIES: args.driftResult.absolute_drift.EQUITIES,
+        BONDS: args.driftResult.absolute_drift.BONDS,
+        CASH: args.driftResult.absolute_drift.CASH,
+      },
+      bands_breached: args.driftResult.bands_breached,
+    };
+  }
+
+  if (args.hasPortfolioStateProvided) {
+    return {
+      status: "cannot_compute" as const,
+    };
+  }
+
+  return {
+    status: "not_applicable" as const,
+  };
+}
+
+function buildPolicyAppliedEvaluation(args: {
+  policy: PolicyJson;
+  hasPortfolioStateProvided: boolean;
+  evaluatedPolicies: string[];
+  skippedPolicies: Array<{ dpq_id: string; reason: string }>;
+  riskGuardrailsUsed: string[];
+  contradictionDetected: boolean;
+  reasonCodes: string[];
+  blockingInputs?: string[];
+}) {
+  const targets = args.policy.strategic_asset_allocation.target_weights;
+  const bands = args.policy.rebalancing_policy.absolute_bands;
+  const totalPolicies = [DPQ_AUTHORITY, DPQ_DRIFT, DPQ_CASHFLOW, DPQ_RISK];
+
+  const evaluated = args.evaluatedPolicies;
+  const skipped = args.skippedPolicies;
+  const evaluatedCount = evaluated.length;
+
+  let status: "applied" | "not_applied" | "partial" | "blocked" = "applied";
+  if (args.contradictionDetected) {
+    status = "blocked";
+  } else if (evaluatedCount === 0) {
+    status = "not_applied";
+  } else if (evaluatedCount < totalPolicies.length || skipped.length > 0) {
+    status = "partial";
+  }
+
+  return {
+    targets: args.hasPortfolioStateProvided ? targets : null,
+    bands: args.hasPortfolioStateProvided ? bands : null,
+    risk_guardrails_used: args.riskGuardrailsUsed,
+    evaluated_policies: evaluated,
+    skipped_policies: skipped,
+    status,
+    reason_codes: args.reasonCodes,
+    blocking_inputs: args.blockingInputs,
+  };
+}
+
+function buildCorrectnessEvaluation(args: {
+  checksRun: string[];
+  contradictionDetected: boolean;
+  hasPortfolioStateProvided: boolean;
+  driftResult: ReturnType<typeof computeDrift> | null;
+  riskEvalStatus: ReturnType<typeof evaluateRiskGuardrails>["status"];
+}) {
+  if (args.contradictionDetected) {
+    return {
+      status: "fail" as const,
+      checks_run: args.checksRun,
+      failed_checks: ["CONTRADICTION_DETECTED"],
+    };
+  }
+
+  if (args.hasPortfolioStateProvided && !args.driftResult) {
+    return {
+      status: "indeterminate" as const,
+      checks_run: args.checksRun,
+      failed_checks: ["DRIFT_CANNOT_COMPUTE"],
+    };
+  }
+
+  if (args.riskEvalStatus === "MISSING_INPUTS") {
+    return {
+      status: "indeterminate" as const,
+      checks_run: args.checksRun,
+      failed_checks: ["RISK_INPUTS_MISSING"],
+    };
+  }
+
+  return {
+    status: "pass" as const,
+    checks_run: args.checksRun,
+  };
 }
 
 /**
@@ -351,6 +469,23 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
         },
       },
       evaluation: {
+        policy_applied: {
+          targets: null,
+          bands: null,
+          risk_guardrails_used: [],
+          evaluated_policies: [],
+          skipped_policies: [],
+          status: "not_applied",
+          reason_codes: ["INVALID_REQUEST"],
+        },
+        correctness: {
+          status: "indeterminate",
+          checks_run: [],
+          failed_checks: ["INVALID_REQUEST"],
+        },
+        drift: {
+          status: "not_applicable",
+        },
         drift_analysis: {
           target_weights: { EQUITIES: 0, BONDS: 0, CASH: 0 },
           actual_weights: { EQUITIES: null, BONDS: null, CASH: null },
@@ -417,9 +552,11 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
    */
   const lastUserMessage = extractLastUserMessage(req.messages);
   const parsedState = lastUserMessage ? extractPortfolioStateFromPrompt(lastUserMessage) : null;
+  const hasPortfolioStateProvided =
+    !!req.portfolio_state && !isEmptyState(req.portfolio_state);
   const structuredState =
     req.portfolio_state &&
-    !isEmptyState(req.portfolio_state) &&
+    hasPortfolioStateProvided &&
     hasCompleteWeights(req.portfolio_state)
       ? req.portfolio_state
       : null;
@@ -465,13 +602,19 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
   const pendingWithdraw = state?.cash_flows.pending_withdrawals_gbp ?? null;
   const hasCashFlows = (pendingContrib ?? 0) > 0 || (pendingWithdraw ?? 0) > 0;
 
-  const baseRecommendationType: RecommendationType = !state || !driftResult
-    ? "ASK_CLARIFYING_QUESTIONS"
-    : hasCashFlows
-      ? "REBALANCE_VIA_CONTRIBUTIONS"
-      : driftResult.bands_breached
-        ? "REBALANCE"
-        : "DO_NOTHING";
+  const baseRecommendationType: RecommendationType = !state
+    ? hasConflict
+      ? "ASK_CLARIFYING_QUESTIONS"
+      : hasPortfolioStateProvided
+        ? "DEFER_AND_REVIEW"
+        : "ASK_CLARIFYING_QUESTIONS"
+    : !driftResult
+      ? "DEFER_AND_REVIEW"
+      : hasCashFlows
+        ? "REBALANCE_VIA_CONTRIBUTIONS"
+        : driftResult.bands_breached
+          ? "REBALANCE"
+          : "DO_NOTHING";
 
   const authorityViolation = evaluateAuthority(authority);
   const riskEval = evaluateRiskGuardrails({
@@ -490,7 +633,7 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
   const policyItems = policyItemsForContext({
     hasAuthorityCheck: true,
     hasDriftCheck: !!driftResult,
-    hasCashflowCheck: hasCashFlows,
+    hasCashflowCheck: !!state,
     hasRiskCheck: true,
   });
 
@@ -554,7 +697,13 @@ Computed drift (deterministic):
 - absolute_drift: equities=${driftResult?.absolute_drift.EQUITIES}, bonds=${driftResult?.absolute_drift.BONDS}, cash=${driftResult?.absolute_drift.CASH}
 - bands_breached: ${driftResult?.bands_breached}
 `
-      : `
+      : hasPortfolioStateProvided
+        ? `
+Portfolio state was provided but is incomplete for deterministic evaluation.
+- Do NOT ask for weights.
+- Defer safely and explain which inputs are missing.
+`
+        : `
 Portfolio state has NOT been provided.
 - Default to ASK_CLARIFYING_QUESTIONS or DEFER_AND_REVIEW.
 - Ask only for the minimum missing inputs required to proceed.
@@ -711,16 +860,37 @@ Portfolio state has NOT been provided.
    * Apply Milestone #3b guardrails (authoritative policy + drift boundaries)
    * ------------------------------------------------------------------
    */
-  const guard = applyGuardrails(
-    {
-      policy,
-      portfolio_state: state,
-      drift: driftResult,
-      risk_inputs: riskInputs,
-      authority,
-    },
-    modelDecision
-  );
+  const contradictionMessage = detectContradiction({
+    expected: expectedRecommendationType,
+    model: modelDecision.recommendation_type,
+    hasState: !!state,
+    driftResult,
+  });
+  const contradictionDetected = !!contradictionMessage;
+
+  const guard = contradictionDetected
+    ? {
+        model: {
+          ...downgradeToDefer(
+            modelDecision,
+            policy,
+            "Contradiction detected between model output and deterministic evaluation."
+          ),
+          proposed_actions: [],
+        },
+        warnings: contradictionMessage ? [contradictionMessage] : [],
+        overridden: true,
+      }
+    : applyGuardrails(
+        {
+          policy,
+          portfolio_state: state,
+          drift: driftResult,
+          risk_inputs: riskInputs,
+          authority,
+        },
+        modelDecision
+      );
 
   if (guard.overridden || guard.warnings.length) {
     console.warn("[APE] Guardrails applied:", guard.warnings);
@@ -758,11 +928,14 @@ Portfolio state has NOT been provided.
    * Build Decision Snapshot
    * ------------------------------------------------------------------
    */
-  const missingInputs = listMissingInputs(state);
-  const outcomeState: OutcomeState =
+  const missingInputs = listMissingInputs(state, hasPortfolioStateProvided);
+  let outcomeState: OutcomeState =
     missingInputs.length > 0 && (!state || expectedRecommendationType === "ASK_CLARIFYING_QUESTIONS")
       ? "CANNOT_DECIDE_MISSING_INPUTS"
       : outcomeFromRecommendation(finalModel.recommendation_type);
+  if (contradictionDetected) {
+    outcomeState = "ERROR_NONRECOVERABLE";
+  }
   const warnings: SnapshotNotice[] = [];
   const errors: SnapshotNotice[] = [];
 
@@ -786,6 +959,23 @@ Portfolio state has NOT been provided.
       code: "AUTHORITY_VIOLATION",
       message: authorityViolation,
       fields: ["authority.actor_role", "authority.decision_intent"],
+    });
+  }
+
+  if (contradictionDetected) {
+    errors.push({
+      code: "CONTRADICTION_DETECTED",
+      message:
+        contradictionMessage ??
+        "Contradiction detected between model output and deterministic evaluation.",
+      fields: ["recommendation.type"],
+    });
+  }
+
+  if (hasPortfolioStateProvided && !driftResult) {
+    warnings.push({
+      code: "DRIFT_CANNOT_COMPUTE",
+      message: "Portfolio state provided but drift could not be computed.",
     });
   }
 
@@ -824,6 +1014,61 @@ Portfolio state has NOT been provided.
         ]
       : []),
   ];
+
+  const evaluatedPolicies: string[] = [];
+  const skippedPolicies: Array<{ dpq_id: string; reason: string }> = [];
+
+  evaluatedPolicies.push(DPQ_AUTHORITY);
+  evaluatedPolicies.push(DPQ_RISK);
+
+  if (driftResult) {
+    evaluatedPolicies.push(DPQ_DRIFT);
+  } else if (hasPortfolioStateProvided) {
+    skippedPolicies.push({ dpq_id: DPQ_DRIFT, reason: REASON_CODES.DRIFT_CANNOT_COMPUTE });
+  } else {
+    skippedPolicies.push({ dpq_id: DPQ_DRIFT, reason: REASON_CODES.MISSING_INPUTS });
+  }
+
+  if (state) {
+    evaluatedPolicies.push(DPQ_CASHFLOW);
+  } else {
+    skippedPolicies.push({ dpq_id: DPQ_CASHFLOW, reason: REASON_CODES.MISSING_INPUTS });
+  }
+
+  const reasonCodes: string[] = [];
+  if (missingInputs.length > 0) reasonCodes.push(REASON_CODES.MISSING_INPUTS);
+  if (hasPortfolioStateProvided && !driftResult) reasonCodes.push(REASON_CODES.DRIFT_CANNOT_COMPUTE);
+  if (contradictionDetected) reasonCodes.push(REASON_CODES.CONTRADICTION_DETECTED);
+
+  const policyApplied = buildPolicyAppliedEvaluation({
+    policy,
+    hasPortfolioStateProvided,
+    evaluatedPolicies,
+    skippedPolicies,
+    riskGuardrailsUsed: [DPQ_RISK],
+    contradictionDetected,
+    reasonCodes: reasonCodes.length ? reasonCodes : [REASON_CODES.POLICY_APPLIED],
+    blockingInputs: missingInputs.length ? missingInputs.map((m) => m.input_key) : undefined,
+  });
+
+  const correctness = buildCorrectnessEvaluation({
+    checksRun: [
+      "AUTHORITY_CHECK",
+      "RISK_GUARDRAILS",
+      "DRIFT_EVALUATION",
+      "CONTRADICTION_CHECK",
+    ],
+    contradictionDetected,
+    hasPortfolioStateProvided,
+    driftResult,
+    riskEvalStatus: riskEval.status,
+  });
+
+  const driftEvaluation = buildDriftEvaluation({
+    hasPortfolioStateProvided,
+    driftResult,
+    policy,
+  });
 
   const snapshot: DecisionSnapshot = {
     snapshot_id: snapshotId,
@@ -885,6 +1130,9 @@ Portfolio state has NOT been provided.
     },
 
     evaluation: {
+      policy_applied: policyApplied,
+      correctness,
+      drift: driftEvaluation,
       drift_analysis: {
         target_weights: {
           EQUITIES: policy.strategic_asset_allocation.target_weights.EQUITIES,
@@ -1041,6 +1289,13 @@ function enforceExplanationContract(args: {
     const mismatchReason = model.explanation.decision_summary.includes("Guardrails override")
       ? model.explanation.decision_summary
       : "Recommendation type mismatch.";
+    if (expectedType === "ASK_CLARIFYING_QUESTIONS") {
+      return {
+        model: forceAsk(model, mismatchReason),
+        warnings,
+        overridden: true,
+      };
+    }
     return {
       model: downgradeToDefer(model, policy, mismatchReason),
       warnings,
@@ -1139,6 +1394,23 @@ function downgradeToDefer(model: ModelDecision, policy: PolicyJson, reason: stri
       reasoning_and_tradeoffs: "Cannot safely justify action; returning defer.",
       uncertainty_and_confidence: "Low confidence due to contract violation.",
       next_review_or_trigger: "Fix explanation contract and retry.",
+    },
+  };
+}
+
+function forceAsk(model: ModelDecision, reason: string): ModelDecision {
+  return {
+    ...model,
+    recommendation_type: "ASK_CLARIFYING_QUESTIONS",
+    recommendation_summary: "Additional inputs required before a recommendation can be made.",
+    proposed_actions: [],
+    explanation: {
+      decision_summary: reason,
+      relevant_portfolio_state: model.explanation.relevant_portfolio_state || "Inputs were missing.",
+      policy_basis: model.explanation.policy_basis,
+      reasoning_and_tradeoffs: "Cannot proceed without required inputs.",
+      uncertainty_and_confidence: "High uncertainty due to missing inputs.",
+      next_review_or_trigger: "Provide the missing inputs and retry.",
     },
   };
 }

--- a/agent/lib/services/decisionSnapshotContract.m3b.test.ts
+++ b/agent/lib/services/decisionSnapshotContract.m3b.test.ts
@@ -1,0 +1,178 @@
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runDecision } from "@/lib/services/decisionService";
+import type { DecisionSnapshot } from "@/lib/domain/decisionSnapshot";
+
+vi.mock("@/lib/infra/policyLoader", () => ({
+  loadPolicy: () => ({
+    policy_id: "ape-policy",
+    policy_version: "0.1-test",
+    source: "test",
+    jurisdiction: "UK",
+    strategic_asset_allocation: {
+      base_currency: "GBP",
+      target_weights: {
+        EQUITIES: 0.8,
+        BONDS: 0.15,
+        CASH: 0.05,
+      },
+    },
+    risk_guardrails: {
+      max_rolling_12m_drawdown_pct: 0.2,
+      risk_capacity_rule: "RISK_CAPACITY_OVERRIDES_TOLERANCE",
+    },
+    rebalancing_policy: {
+      absolute_bands: {
+        EQUITIES: 0.05,
+        BONDS: 0.04,
+        CASH: 0.02,
+      },
+    },
+    constraints: {
+      prohibited_actions: ["LEVERAGE", "MARGIN", "MARKET_TIMING"],
+    },
+  }),
+}));
+
+const mastra = vi.hoisted(() => ({
+  generateAssistantReply: vi.fn(),
+}));
+
+vi.mock("@/lib/infra/mastra", () => ({
+  generateAssistantReply: mastra.generateAssistantReply,
+}));
+
+const baseModel = {
+  recommendation_type: "DO_NOTHING",
+  recommendation_summary: "Policy-aligned recommendation.",
+  proposed_actions: [],
+  explanation: {
+    decision_summary: "Decision follows the investment policy guardrails.",
+    relevant_portfolio_state: "Inputs were parsed from the request.",
+    policy_basis:
+      "Targets: equities 0.8, bonds 0.15, cash 0.05. Bands: equities 0.05, bonds 0.04, cash 0.02. Policy ape-policy v0.1-test (test).",
+    reasoning_and_tradeoffs: "Guardrails prevent unnecessary action.",
+    uncertainty_and_confidence: "High confidence given deterministic inputs.",
+    next_review_or_trigger: "Review if inputs or cash flows change.",
+  },
+};
+
+function mockModelResponse(payload: typeof baseModel) {
+  mastra.generateAssistantReply.mockResolvedValue(JSON.stringify(payload));
+}
+
+describe("Decision Snapshot contract (M3b)", () => {
+  beforeEach(() => {
+    mastra.generateAssistantReply.mockReset();
+    mockModelResponse(baseModel);
+  });
+
+  it("populates policy_applied and drift evaluation for a full apply pass", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content: "Evaluate my portfolio and generate a decision snapshot.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
+        cash_flows: { pending_contributions_gbp: 0, pending_withdrawals_gbp: 0 },
+      },
+      risk_inputs: { rolling_12m_drawdown_pct: 0.1, risk_capacity_breached: false },
+    });
+
+    const evalBlock = result.snapshot.evaluation;
+    expect(evalBlock.policy_applied.targets).toEqual({
+      EQUITIES: 0.8,
+      BONDS: 0.15,
+      CASH: 0.05,
+    });
+    expect(evalBlock.policy_applied.bands).toEqual({
+      EQUITIES: 0.05,
+      BONDS: 0.04,
+      CASH: 0.02,
+    });
+    expect(evalBlock.policy_applied.risk_guardrails_used).toContain("DPQ-004");
+    expect(evalBlock.policy_applied.status).toBe("applied");
+
+    expect(evalBlock.drift.status).toBe("computed");
+    expect(typeof evalBlock.drift.bands_breached).toBe("boolean");
+
+    expect(evalBlock.correctness.status).toBe("pass");
+  });
+
+  it("does not request weights when portfolio_state exists but weights are missing", async () => {
+    const result = await runDecision({
+      messages: [{ role: "user", content: "Evaluate my portfolio." }],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: null, BONDS: null, CASH: null },
+        cash_flows: { pending_contributions_gbp: null, pending_withdrawals_gbp: null },
+      },
+      risk_inputs: { rolling_12m_drawdown_pct: 0.1, risk_capacity_breached: false },
+    });
+
+    expect(result.snapshot.recommendation.type).not.toBe("ASK_CLARIFYING_QUESTIONS");
+    const missing = result.snapshot.inputs_missing.map((m) => m.input_key);
+    expect(missing).not.toContain("portfolio_state.weights");
+    expect(result.snapshot.evaluation.drift.status).toBe("cannot_compute");
+  });
+
+  it("rejects contradictory model output with correctness=fail", async () => {
+    mockModelResponse({ ...baseModel, recommendation_type: "REBALANCE" });
+
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content: "Evaluate my portfolio and generate a decision snapshot.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
+        cash_flows: { pending_contributions_gbp: 0, pending_withdrawals_gbp: 0 },
+      },
+      risk_inputs: { rolling_12m_drawdown_pct: 0.1, risk_capacity_breached: false },
+    });
+
+    expect(result.snapshot.outcome_state).toBe("ERROR_NONRECOVERABLE");
+    expect(result.snapshot.evaluation.correctness.status).toBe("fail");
+    expect(result.snapshot.evaluation.policy_applied.status).not.toBe("applied");
+    expect(result.snapshot.errors.map((e) => e.code)).toContain("CONTRADICTION_DETECTED");
+  });
+
+  it("golden snapshot exists and includes M3b evaluation fields", () => {
+    const repoRoot = path.resolve(process.cwd(), "..");
+    const snapshotPath = path.join(
+      repoRoot,
+      "artifacts",
+      "reference",
+      "milestone-3b",
+      "scenario_1_full_apply_pass.json"
+    );
+
+    const raw = readFileSync(snapshotPath, "utf-8");
+    const snapshot = JSON.parse(raw) as DecisionSnapshot;
+
+    expect(snapshot.evaluation.policy_applied).toBeTruthy();
+    expect(snapshot.evaluation.correctness).toBeTruthy();
+    expect(snapshot.evaluation.drift).toBeTruthy();
+  });
+
+  it("marks drift as not_applicable when no portfolio_state is provided", async () => {
+    const result = await runDecision({
+      messages: [{ role: "user", content: "Evaluate my portfolio." }],
+    });
+
+    expect(result.snapshot.evaluation.drift.status).toBe("not_applicable");
+    expect(result.snapshot.evaluation.correctness.status).toBe("indeterminate");
+  });
+});

--- a/artifacts/reference/milestone-3b/scenario_1_full_apply_pass.json
+++ b/artifacts/reference/milestone-3b/scenario_1_full_apply_pass.json
@@ -1,0 +1,119 @@
+{
+  "snapshot_id": "00000000-0000-0000-0000-000000000000",
+  "snapshot_version": "0.3",
+  "created_at": "2026-02-07T00:00:00Z",
+  "project": "AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)",
+  "outcome_state": "RECOMMEND_NO_ACTION",
+  "inputs_observed": [
+    { "input_key": "portfolio_state.weights", "value": "provided", "source": "form" },
+    { "input_key": "portfolio_state.cash_flows", "value": "provided", "source": "form" },
+    { "input_key": "portfolio_state.total_value", "value": 100000, "source": "form" }
+  ],
+  "inputs_missing": [],
+  "policy_items_referenced": [
+    { "dpq_id": "DPQ-001" },
+    { "dpq_id": "DPQ-002" },
+    { "dpq_id": "DPQ-003" },
+    { "dpq_id": "DPQ-004" }
+  ],
+  "warnings": [],
+  "errors": [],
+  "context": {
+    "user_id": "sample",
+    "environment": "reference",
+    "jurisdiction": "UK",
+    "base_currency": "GBP"
+  },
+  "inputs": {
+    "portfolio_state": {
+      "total_value": 100000,
+      "asset_allocation": { "EQUITIES": 0.78, "BONDS": 0.16, "CASH": 0.06 },
+      "positions_summary": "Structured portfolio state provided (manual input).",
+      "cash_balance": null
+    },
+    "cash_flows": {
+      "pending_contributions": 0,
+      "pending_withdrawals": 0,
+      "notes": "No cash flows provided."
+    },
+    "constraints": {
+      "liquidity_needs": "Not captured yet.",
+      "tax_or_wrapper_constraints": "Not captured yet.",
+      "other_constraints": "Not captured yet."
+    },
+    "market_context": {
+      "as_of_date": "2026-02-07",
+      "notes": "No exceptional market context assumed."
+    }
+  },
+  "governance": {
+    "investment_policy": {
+      "policy_id": "ape-policy",
+      "policy_version": "0.1-default",
+      "policy_source": "default"
+    },
+    "explanation_contract": { "version": "0.1-default" }
+  },
+  "evaluation": {
+    "policy_applied": {
+      "targets": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "bands": { "EQUITIES": 0.05, "BONDS": 0.04, "CASH": 0.02 },
+      "risk_guardrails_used": ["DPQ-004"],
+      "evaluated_policies": ["DPQ-001", "DPQ-002", "DPQ-003", "DPQ-004"],
+      "skipped_policies": [],
+      "status": "applied",
+      "reason_codes": ["POLICY_APPLIED"]
+    },
+    "correctness": {
+      "status": "pass",
+      "checks_run": ["AUTHORITY_CHECK", "RISK_GUARDRAILS", "DRIFT_EVALUATION", "CONTRADICTION_CHECK"]
+    },
+    "drift": {
+      "status": "computed",
+      "target_weights": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "actual_weights": { "EQUITIES": 0.78, "BONDS": 0.16, "CASH": 0.06 },
+      "absolute_drift": { "EQUITIES": -0.02, "BONDS": 0.01, "CASH": 0.01 },
+      "bands_breached": false
+    },
+    "drift_analysis": {
+      "target_weights": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "actual_weights": { "EQUITIES": 0.78, "BONDS": 0.16, "CASH": 0.06 },
+      "absolute_drift": { "EQUITIES": -0.02, "BONDS": 0.01, "CASH": 0.01 },
+      "bands_breached": false
+    },
+    "risk_checks": {
+      "drawdown_proximity": "Not evaluated.",
+      "risk_capacity_breached": false,
+      "notes": "Risk guardrails satisfied."
+    }
+  },
+  "recommendation": {
+    "type": "DO_NOTHING",
+    "summary": "No action required; portfolio is within policy rebalancing bands.",
+    "proposed_actions": [],
+    "turnover_estimate": { "gross_turnover_pct": 0, "trade_count": 0 }
+  },
+  "explanation": {
+    "decision_summary": "Portfolio is within policy bands and no action is required.",
+    "relevant_portfolio_state": "Weights are within target bands with no cash flows.",
+    "policy_basis": "Policy targets and bands were applied.",
+    "reasoning_and_tradeoffs": "Rebalancing is unnecessary without a band breach.",
+    "uncertainty_and_confidence": "High confidence given deterministic inputs.",
+    "next_review_or_trigger": "Review at next scheduled check or if inputs change."
+  },
+  "user_acknowledgement": {
+    "decision": "DEFER",
+    "user_notes": "Reference snapshot.",
+    "acknowledged_at": null
+  },
+  "outcome": {
+    "implemented": null,
+    "implementation_notes": null,
+    "review_date": null,
+    "observed_effects": null
+  },
+  "audit": {
+    "logic_version": "0.3",
+    "notes": "Reference snapshot for Milestone 3b."
+  }
+}

--- a/artifacts/reference/milestone-3b/scenario_2_portfolio_state_no_weights_pass_or_indeterminate.json
+++ b/artifacts/reference/milestone-3b/scenario_2_portfolio_state_no_weights_pass_or_indeterminate.json
@@ -1,0 +1,120 @@
+{
+  "snapshot_id": "00000000-0000-0000-0000-000000000001",
+  "snapshot_version": "0.3",
+  "created_at": "2026-02-07T00:00:00Z",
+  "project": "AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)",
+  "outcome_state": "CANNOT_DECIDE_MISSING_INPUTS",
+  "inputs_observed": [
+    { "input_key": "portfolio_state.weights", "value": "provided", "source": "form" },
+    { "input_key": "portfolio_state.cash_flows", "value": "provided", "source": "form" }
+  ],
+  "inputs_missing": [
+    { "input_key": "portfolio_state.cash_flows", "impact": "Required to assess cashflow-driven rebalancing." },
+    { "input_key": "portfolio_state.total_value", "impact": "Required for sizing and validation." }
+  ],
+  "policy_items_referenced": [
+    { "dpq_id": "DPQ-001" },
+    { "dpq_id": "DPQ-004" }
+  ],
+  "warnings": [
+    { "code": "DRIFT_CANNOT_COMPUTE", "message": "Portfolio state provided but drift could not be computed." }
+  ],
+  "errors": [],
+  "context": {
+    "user_id": "sample",
+    "environment": "reference",
+    "jurisdiction": "UK",
+    "base_currency": "GBP"
+  },
+  "inputs": {
+    "portfolio_state": {
+      "total_value": null,
+      "asset_allocation": { "EQUITIES": null, "BONDS": null, "CASH": null },
+      "positions_summary": "Structured portfolio state provided (manual input).",
+      "cash_balance": null
+    },
+    "cash_flows": {
+      "pending_contributions": null,
+      "pending_withdrawals": null,
+      "notes": "Not provided."
+    },
+    "constraints": {
+      "liquidity_needs": "Not captured yet.",
+      "tax_or_wrapper_constraints": "Not captured yet.",
+      "other_constraints": "Not captured yet."
+    },
+    "market_context": {
+      "as_of_date": "2026-02-07",
+      "notes": "No exceptional market context assumed."
+    }
+  },
+  "governance": {
+    "investment_policy": {
+      "policy_id": "ape-policy",
+      "policy_version": "0.1-default",
+      "policy_source": "default"
+    },
+    "explanation_contract": { "version": "0.1-default" }
+  },
+  "evaluation": {
+    "policy_applied": {
+      "targets": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "bands": { "EQUITIES": 0.05, "BONDS": 0.04, "CASH": 0.02 },
+      "risk_guardrails_used": ["DPQ-004"],
+      "evaluated_policies": ["DPQ-001", "DPQ-004"],
+      "skipped_policies": [
+        { "dpq_id": "DPQ-002", "reason": "DRIFT_CANNOT_COMPUTE" },
+        { "dpq_id": "DPQ-003", "reason": "MISSING_INPUTS" }
+      ],
+      "status": "partial",
+      "reason_codes": ["DRIFT_CANNOT_COMPUTE", "MISSING_INPUTS"],
+      "blocking_inputs": ["portfolio_state.cash_flows", "portfolio_state.total_value"]
+    },
+    "correctness": {
+      "status": "indeterminate",
+      "checks_run": ["AUTHORITY_CHECK", "RISK_GUARDRAILS", "DRIFT_EVALUATION", "CONTRADICTION_CHECK"],
+      "failed_checks": ["DRIFT_CANNOT_COMPUTE"]
+    },
+    "drift": { "status": "cannot_compute" },
+    "drift_analysis": {
+      "target_weights": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "actual_weights": { "EQUITIES": null, "BONDS": null, "CASH": null },
+      "absolute_drift": { "EQUITIES": null, "BONDS": null, "CASH": null },
+      "bands_breached": null
+    },
+    "risk_checks": {
+      "drawdown_proximity": "Not evaluated.",
+      "risk_capacity_breached": null,
+      "notes": "Risk guardrails evaluated with missing inputs."
+    }
+  },
+  "recommendation": {
+    "type": "DEFER_AND_REVIEW",
+    "summary": "Defer and review required before proceeding.",
+    "proposed_actions": [],
+    "turnover_estimate": { "gross_turnover_pct": null, "trade_count": 0 }
+  },
+  "explanation": {
+    "decision_summary": "Portfolio state was provided but drift could not be computed.",
+    "relevant_portfolio_state": "Portfolio state present but incomplete for drift computation.",
+    "policy_basis": "Policy requires deterministic drift before action.",
+    "reasoning_and_tradeoffs": "Cannot safely recommend without complete deterministic inputs.",
+    "uncertainty_and_confidence": "High uncertainty due to missing inputs.",
+    "next_review_or_trigger": "Provide required inputs and retry."
+  },
+  "user_acknowledgement": {
+    "decision": "DEFER",
+    "user_notes": "Reference snapshot.",
+    "acknowledged_at": null
+  },
+  "outcome": {
+    "implemented": null,
+    "implementation_notes": null,
+    "review_date": null,
+    "observed_effects": null
+  },
+  "audit": {
+    "logic_version": "0.3",
+    "notes": "Reference snapshot for Milestone 3b (portfolio_state provided, drift not computed)."
+  }
+}

--- a/artifacts/reference/milestone-3b/scenario_3_missing_inputs_indeterminate_or_blocked.json
+++ b/artifacts/reference/milestone-3b/scenario_3_missing_inputs_indeterminate_or_blocked.json
@@ -1,0 +1,115 @@
+{
+  "snapshot_id": "00000000-0000-0000-0000-000000000002",
+  "snapshot_version": "0.3",
+  "created_at": "2026-02-07T00:00:00Z",
+  "project": "AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)",
+  "outcome_state": "CANNOT_DECIDE_MISSING_INPUTS",
+  "inputs_observed": [],
+  "inputs_missing": [
+    { "input_key": "portfolio_state.weights", "impact": "Required to compute drift and recommendation." },
+    { "input_key": "portfolio_state.cash_flows", "impact": "Required to assess cashflow-driven rebalancing." },
+    { "input_key": "portfolio_state.total_value", "impact": "Required for sizing and validation." }
+  ],
+  "policy_items_referenced": [],
+  "warnings": [
+    { "code": "MISSING_INPUTS", "message": "Portfolio state missing; cannot compute drift." }
+  ],
+  "errors": [],
+  "context": {
+    "user_id": "sample",
+    "environment": "reference",
+    "jurisdiction": "UK",
+    "base_currency": "GBP"
+  },
+  "inputs": {
+    "portfolio_state": {
+      "total_value": null,
+      "asset_allocation": { "EQUITIES": null, "BONDS": null, "CASH": null },
+      "positions_summary": "Not provided.",
+      "cash_balance": null
+    },
+    "cash_flows": {
+      "pending_contributions": null,
+      "pending_withdrawals": null,
+      "notes": "Not provided."
+    },
+    "constraints": {
+      "liquidity_needs": "Not captured yet.",
+      "tax_or_wrapper_constraints": "Not captured yet.",
+      "other_constraints": "Not captured yet."
+    },
+    "market_context": {
+      "as_of_date": "2026-02-07",
+      "notes": "No exceptional market context assumed."
+    }
+  },
+  "governance": {
+    "investment_policy": {
+      "policy_id": "ape-policy",
+      "policy_version": "0.1-default",
+      "policy_source": "default"
+    },
+    "explanation_contract": { "version": "0.1-default" }
+  },
+  "evaluation": {
+    "policy_applied": {
+      "targets": null,
+      "bands": null,
+      "risk_guardrails_used": ["DPQ-004"],
+      "evaluated_policies": ["DPQ-001", "DPQ-004"],
+      "skipped_policies": [
+        { "dpq_id": "DPQ-002", "reason": "MISSING_INPUTS" },
+        { "dpq_id": "DPQ-003", "reason": "MISSING_INPUTS" }
+      ],
+      "status": "partial",
+      "reason_codes": ["MISSING_INPUTS"],
+      "blocking_inputs": ["portfolio_state.weights", "portfolio_state.cash_flows", "portfolio_state.total_value"]
+    },
+    "correctness": {
+      "status": "indeterminate",
+      "checks_run": ["AUTHORITY_CHECK", "RISK_GUARDRAILS", "DRIFT_EVALUATION", "CONTRADICTION_CHECK"],
+      "failed_checks": ["DRIFT_CANNOT_COMPUTE"]
+    },
+    "drift": { "status": "not_applicable" },
+    "drift_analysis": {
+      "target_weights": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "actual_weights": { "EQUITIES": null, "BONDS": null, "CASH": null },
+      "absolute_drift": { "EQUITIES": null, "BONDS": null, "CASH": null },
+      "bands_breached": null
+    },
+    "risk_checks": {
+      "drawdown_proximity": "Not evaluated.",
+      "risk_capacity_breached": null,
+      "notes": "Risk guardrails evaluated with missing inputs."
+    }
+  },
+  "recommendation": {
+    "type": "ASK_CLARIFYING_QUESTIONS",
+    "summary": "Additional inputs required before a recommendation can be made.",
+    "proposed_actions": [],
+    "turnover_estimate": { "gross_turnover_pct": null, "trade_count": 0 }
+  },
+  "explanation": {
+    "decision_summary": "Missing inputs; please provide portfolio weights and cash flows.",
+    "relevant_portfolio_state": "No portfolio state provided.",
+    "policy_basis": "Policy requires deterministic portfolio inputs before recommendations.",
+    "reasoning_and_tradeoffs": "Cannot compute drift or guardrails without required inputs.",
+    "uncertainty_and_confidence": "High uncertainty due to missing inputs.",
+    "next_review_or_trigger": "Provide portfolio state and retry."
+  },
+  "user_acknowledgement": {
+    "decision": "DEFER",
+    "user_notes": "Reference snapshot.",
+    "acknowledged_at": null
+  },
+  "outcome": {
+    "implemented": null,
+    "implementation_notes": null,
+    "review_date": null,
+    "observed_effects": null
+  },
+  "audit": {
+    "logic_version": "0.3",
+    "notes": "Reference snapshot for Milestone 3b (missing inputs)."
+  }
+}

--- a/artifacts/reference/milestone-3b/scenario_4_contradiction_rejected_fail.json
+++ b/artifacts/reference/milestone-3b/scenario_4_contradiction_rejected_fail.json
@@ -1,0 +1,119 @@
+{
+  "snapshot_id": "00000000-0000-0000-0000-000000000003",
+  "snapshot_version": "0.3",
+  "created_at": "2026-02-07T00:00:00Z",
+  "project": "AI Portfolio Decision Co-Pilot (Automated Portfolio Evaluator)",
+  "outcome_state": "ERROR_NONRECOVERABLE",
+  "inputs_observed": [
+    { "input_key": "portfolio_state.weights", "value": "provided", "source": "form" },
+    { "input_key": "portfolio_state.cash_flows", "value": "provided", "source": "form" }
+  ],
+  "inputs_missing": [],
+  "policy_items_referenced": [
+    { "dpq_id": "DPQ-002" }
+  ],
+  "warnings": [],
+  "errors": [
+    { "code": "CONTRADICTION_DETECTED", "message": "Model recommendation REBALANCE contradicts deterministic expectation DO_NOTHING.", "fields": ["recommendation.type"] }
+  ],
+  "context": {
+    "user_id": "sample",
+    "environment": "reference",
+    "jurisdiction": "UK",
+    "base_currency": "GBP"
+  },
+  "inputs": {
+    "portfolio_state": {
+      "total_value": 100000,
+      "asset_allocation": { "EQUITIES": 0.78, "BONDS": 0.16, "CASH": 0.06 },
+      "positions_summary": "Structured portfolio state provided (manual input).",
+      "cash_balance": null
+    },
+    "cash_flows": {
+      "pending_contributions": 0,
+      "pending_withdrawals": 0,
+      "notes": "No cash flows provided."
+    },
+    "constraints": {
+      "liquidity_needs": "Not captured yet.",
+      "tax_or_wrapper_constraints": "Not captured yet.",
+      "other_constraints": "Not captured yet."
+    },
+    "market_context": {
+      "as_of_date": "2026-02-07",
+      "notes": "No exceptional market context assumed."
+    }
+  },
+  "governance": {
+    "investment_policy": {
+      "policy_id": "ape-policy",
+      "policy_version": "0.1-default",
+      "policy_source": "default"
+    },
+    "explanation_contract": { "version": "0.1-default" }
+  },
+  "evaluation": {
+    "policy_applied": {
+      "targets": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "bands": { "EQUITIES": 0.05, "BONDS": 0.04, "CASH": 0.02 },
+      "risk_guardrails_used": ["DPQ-004"],
+      "evaluated_policies": ["DPQ-001", "DPQ-002", "DPQ-003", "DPQ-004"],
+      "skipped_policies": [],
+      "status": "blocked",
+      "reason_codes": ["CONTRADICTION_DETECTED"],
+      "blocking_inputs": []
+    },
+    "correctness": {
+      "status": "fail",
+      "checks_run": ["AUTHORITY_CHECK", "RISK_GUARDRAILS", "DRIFT_EVALUATION", "CONTRADICTION_CHECK"],
+      "failed_checks": ["CONTRADICTION_DETECTED"]
+    },
+    "drift": {
+      "status": "computed",
+      "target_weights": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "actual_weights": { "EQUITIES": 0.78, "BONDS": 0.16, "CASH": 0.06 },
+      "absolute_drift": { "EQUITIES": -0.02, "BONDS": 0.01, "CASH": 0.01 },
+      "bands_breached": false
+    },
+    "drift_analysis": {
+      "target_weights": { "EQUITIES": 0.8, "BONDS": 0.15, "CASH": 0.05 },
+      "actual_weights": { "EQUITIES": 0.78, "BONDS": 0.16, "CASH": 0.06 },
+      "absolute_drift": { "EQUITIES": -0.02, "BONDS": 0.01, "CASH": 0.01 },
+      "bands_breached": false
+    },
+    "risk_checks": {
+      "drawdown_proximity": "Not evaluated.",
+      "risk_capacity_breached": false,
+      "notes": "Risk guardrails satisfied."
+    }
+  },
+  "recommendation": {
+    "type": "DEFER_AND_REVIEW",
+    "summary": "Defer and review required before proceeding.",
+    "proposed_actions": [],
+    "turnover_estimate": { "gross_turnover_pct": 0, "trade_count": 0 }
+  },
+  "explanation": {
+    "decision_summary": "Contradiction detected between model output and deterministic evaluation.",
+    "relevant_portfolio_state": "Weights are within target bands with no cash flows.",
+    "policy_basis": "Policy targets and bands were applied.",
+    "reasoning_and_tradeoffs": "Cannot accept contradictory model output; safe fallback applied.",
+    "uncertainty_and_confidence": "High confidence in deterministic guardrails.",
+    "next_review_or_trigger": "Retry with corrected model output."
+  },
+  "user_acknowledgement": {
+    "decision": "DEFER",
+    "user_notes": "Reference snapshot.",
+    "acknowledged_at": null
+  },
+  "outcome": {
+    "implemented": null,
+    "implementation_notes": null,
+    "review_date": null,
+    "observed_effects": null
+  },
+  "audit": {
+    "logic_version": "0.3",
+    "notes": "Reference snapshot for Milestone 3b (contradiction rejection)."
+  }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -121,5 +121,43 @@
 
 ---
 
+## 2026-02-07 — Iteration M3b (Show Your Work)
+### Added
+- Evaluation fields for policy application (`policy_applied`), deterministic drift (`drift`), and correctness (`correctness`).
+- Contradiction rejection with deterministic fail status and structured error codes.
+- Golden reference snapshots under `artifacts/reference/milestone-3b/` (reference outputs only).
+
+### Changed
+- If `portfolio_state` exists, the system never asks for weights.
+- Deterministic drift and policy application details are now explicit in snapshots.
+
+### Fixed
+- N/A
+
+### Removed
+- N/A
+
+### Data / Schema
+- Decision Snapshot evaluation section expanded to include policy-applied provenance, drift status, and correctness status.
+
+### Risks / Follow-ups
+- M3c guardrail expansions remain out of scope.
+
+### Manual regression checks (quick)
+- [ ] Portfolio state present → no request for weights; drift status is deterministic.
+- [ ] Contradiction between model output and deterministic expectation yields `correctness=fail`.
+- [ ] Drift evaluation is populated or explicitly marked not applicable/cannot compute.
+
+### Tests
+- `cd agent && npm test`
+
+### Paths touched
+- `agent/lib/domain/decisionSnapshot.ts`
+- `agent/lib/services/decisionService.ts`
+- `agent/lib/services/decisionSnapshotContract.m3b.test.ts`
+- `artifacts/reference/milestone-3b/*`
+
+---
+
 ## Milestone 3c Marker
 Backfilled documentation is complete through Milestone 3c.


### PR DESCRIPTION
Title

Milestone 3b: “Show your work” evaluation + drift + contradiction rejection

What changed

Extended Decision Snapshot contract with M3b evaluation fields (evaluation.policy_applied, evaluation.correctness, drift fields)

Populated deterministic M3b evaluation in decisionService.ts

If portfolio_state exists → never ask for weights

Deterministic drift evaluation

Deterministic contradiction detection → reject model output

Added M3b contract tests + golden reference snapshots

Why

M3b is the correctness/visibility layer that makes policy application explicit and auditable so downstream milestones can rely on correctness states without re-deriving intent.

Scope guardrails

✅ M3b only: correctness + policy/guardrail visibility + deterministic rejection

❌ No M3c guardrails expansion, no heuristics, no changes to M1/M2 artefacts

How to test
cd agent
npm test

Files changed/added

agent/lib/domain/decisionSnapshot.ts

agent/lib/services/decisionService.ts

agent/lib/services/decisionSnapshotContract.m3b.test.ts (new)

artifacts/reference/milestone-3b/*.json (new)

Review notes

Golden snapshots are reference outputs only; runtime does not read from artifacts/.

Pay special attention to:

correctness state transitions (pass|fail|indeterminate)

drift determinism

contradiction rejection path + error codes

no-ask-for-weights rule when portfolio_state exists
