### PR TITLE
[M3b] Enforce runtime policy loading boundary

### DIFF
--- a/agent/lib/infra/policyLoader.test.ts
+++ b/agent/lib/infra/policyLoader.test.ts
@@ -1,68 +1,119 @@
-import { describe, expect, it, vi } from "vitest";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
 
-const policyJson = JSON.stringify({
-  policy_id: "ape-policy",
-  policy_version: "0.1-test",
-  source: "test",
-  jurisdiction: "UK",
-  strategic_asset_allocation: {
-    base_currency: "GBP",
-    target_weights: {
-      EQUITIES: 0.6,
-      BONDS: 0.35,
-      CASH: 0.05,
+function sha256Text(text: string): string {
+  return crypto.createHash("sha256").update(text, "utf-8").digest("hex");
+}
+
+function writePolicyDir(args: {
+  dir: string;
+  filename: "policy.local.json" | "policy.default.json";
+  primeFilename: "prime_directive.local.md" | "prime_directive.default.md";
+  primeText: string;
+}): void {
+  const { dir, filename, primeFilename, primeText } = args;
+  fs.mkdirSync(dir, { recursive: true });
+
+  const policyJson = {
+    policy_id: "ape-policy",
+    policy_version: "0.1-test",
+    source: "test",
+    jurisdiction: "UK",
+    strategic_asset_allocation: {
+      base_currency: "GBP",
+      target_weights: {
+        EQUITIES: 0.6,
+        BONDS: 0.35,
+        CASH: 0.05,
+      },
     },
-  },
-  risk_guardrails: {
-    max_rolling_12m_drawdown_pct: 0.2,
-    risk_capacity_rule: "RISK_CAPACITY_OVERRIDES_TOLERANCE",
-  },
-  rebalancing_policy: {
-    absolute_bands: {
-      EQUITIES: 0.07,
-      BONDS: 0.06,
-      CASH: 0.03,
+    risk_guardrails: {
+      max_rolling_12m_drawdown_pct: 0.2,
+      risk_capacity_rule: "RISK_CAPACITY_OVERRIDES_TOLERANCE",
     },
-  },
-  constraints: {
-    prohibited_actions: ["LEVERAGE"],
-  },
-  meta: {
-    prime_directive_sha256: "deadbeef",
-  },
-});
-
-const primeDirectiveText = "# Prime Directive Statement\n\nTest content.";
-
-vi.mock("node:fs", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:fs")>();
-  const existsSync = (p: string) =>
-    p.includes("policy.default.json") || p.includes("prime_directive.default.md");
-  const readFileSync = (p: string, encoding?: string) => {
-    if (p.includes("policy.default.json")) {
-      return policyJson;
-    }
-    if (p.includes("prime_directive.default.md")) {
-      return encoding ? primeDirectiveText : Buffer.from(primeDirectiveText, "utf-8");
-    }
-    throw new Error(`Unexpected read: ${p}`);
-  };
-
-  return {
-    ...actual,
-    existsSync,
-    readFileSync,
-    default: {
-      ...(actual as typeof import("node:fs")),
-      existsSync,
-      readFileSync,
+    rebalancing_policy: {
+      absolute_bands: {
+        EQUITIES: 0.07,
+        BONDS: 0.06,
+        CASH: 0.03,
+      },
+    },
+    constraints: {
+      prohibited_actions: ["LEVERAGE"],
+    },
+    meta: {
+      prime_directive_sha256: sha256Text(primeText),
     },
   };
-});
 
-describe("loadPolicy governance freeze", () => {
-  it("fails fast when prime directive hash does not match pin", async () => {
+  fs.writeFileSync(path.join(dir, filename), JSON.stringify(policyJson, null, 2), "utf-8");
+  fs.writeFileSync(path.join(dir, primeFilename), primeText, "utf-8");
+}
+
+describe.sequential("policyLoader env resolution", () => {
+  const originalEnv = { ...process.env };
+  const originalCwd = process.cwd();
+
+  function resetEnv(): void {
+    process.env = { ...originalEnv };
+  }
+
+  it("throws when no POLICY_* is set and artifacts reads are not allowed", async () => {
+    resetEnv();
+    delete process.env.POLICY_PATH;
+    delete process.env.POLICY_DIR;
+    delete process.env.ALLOW_ARTIFACTS_READ;
+
     const { loadPolicy } = await import("./policyLoader");
-    expect(() => loadPolicy()).toThrow(/Prime Directive mismatch/);
+    expect(() => loadPolicy()).toThrow(/POLICY_(PATH|DIR)/i);
+  });
+
+  it("loads policy via POLICY_DIR when present", async () => {
+    resetEnv();
+    delete process.env.POLICY_PATH;
+    delete process.env.ALLOW_ARTIFACTS_READ;
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ape-policy-"));
+    const primeText = "# Prime Directive Statement\n\nTest content.";
+    writePolicyDir({
+      dir: tmpDir,
+      filename: "policy.default.json",
+      primeFilename: "prime_directive.default.md",
+      primeText,
+    });
+
+    process.env.POLICY_DIR = tmpDir;
+    const { loadPolicy } = await import("./policyLoader");
+    const policy = loadPolicy();
+    expect(policy.policy_id).toBe("ape-policy");
+  });
+
+  it("allows legacy artifacts fallback only when ALLOW_ARTIFACTS_READ=true", async () => {
+    resetEnv();
+    delete process.env.POLICY_PATH;
+    delete process.env.POLICY_DIR;
+    process.env.ALLOW_ARTIFACTS_READ = "true";
+
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ape-artifacts-"));
+    const artifactsDir = path.join(tmpRoot, "artifacts", "policy", "default");
+    const primeText = "# Prime Directive Statement\n\nTest content.";
+    writePolicyDir({
+      dir: artifactsDir,
+      filename: "policy.default.json",
+      primeFilename: "prime_directive.default.md",
+      primeText,
+    });
+
+    process.chdir(tmpRoot);
+    try {
+      const { loadPolicy } = await import("./policyLoader");
+      const policy = loadPolicy();
+      expect(policy.policy_id).toBe("ape-policy");
+    } finally {
+      process.chdir(originalCwd);
+    }
   });
 });

--- a/agent/lib/infra/policyLoader.ts
+++ b/agent/lib/infra/policyLoader.ts
@@ -59,6 +59,63 @@ function firstExisting(paths: string[]): string | null {
   return null;
 }
 
+function resolvePolicyPathFromEnv(): string | null {
+  const policyPathEnv = process.env.POLICY_PATH?.trim();
+  if (policyPathEnv && policyPathEnv.length > 0) {
+    return path.isAbsolute(policyPathEnv) ? policyPathEnv : path.resolve(process.cwd(), policyPathEnv);
+  }
+
+  const policyDir = process.env.POLICY_DIR?.trim();
+  if (policyDir && policyDir.length > 0) {
+    const baseDir = path.isAbsolute(policyDir) ? policyDir : path.resolve(process.cwd(), policyDir);
+    const candidates = [
+      path.join(baseDir, "policy.local.json"),
+      path.join(baseDir, "policy.default.json"),
+    ];
+    return firstExisting(candidates);
+  }
+
+  return null;
+}
+
+function resolvePrimeDirectivePath(args: {
+  policyPath: string;
+  allowArtifacts: boolean;
+}): string | null {
+  const { policyPath, allowArtifacts } = args;
+  const policyDirEnv = process.env.POLICY_DIR?.trim();
+  const policyDir = policyDirEnv
+    ? path.isAbsolute(policyDirEnv)
+      ? policyDirEnv
+      : path.resolve(process.cwd(), policyDirEnv)
+    : path.dirname(policyPath);
+
+  const isLocal = policyPath.includes("policy.local.json");
+  const localFirst = isLocal
+    ? ["prime_directive.local.md", "prime_directive.default.md"]
+    : ["prime_directive.default.md", "prime_directive.local.md"];
+
+  const candidates = localFirst.map((name) => path.join(policyDir, name));
+
+  if (allowArtifacts) {
+    const cwd = process.cwd();
+    const artifactCandidates = isLocal
+      ? [
+          path.resolve(cwd, "artifacts/local/prime_directive.local.md"),
+          path.resolve(cwd, "..", "artifacts/local/prime_directive.local.md"),
+          "/artifacts/local/prime_directive.local.md",
+        ]
+      : [
+          path.resolve(cwd, "artifacts/policy/default/prime_directive.default.md"),
+          path.resolve(cwd, "..", "artifacts/policy/default/prime_directive.default.md"),
+          "/artifacts/policy/default/prime_directive.default.md",
+        ];
+    candidates.push(...artifactCandidates);
+  }
+
+  return firstExisting(candidates);
+}
+
 function sha256File(absPath: string): string {
   const raw = fs.readFileSync(absPath);
   return crypto.createHash("sha256").update(raw).digest("hex");
@@ -67,29 +124,16 @@ function sha256File(absPath: string): string {
 function enforcePrimeDirectiveFreeze(args: {
   policy: PolicyJson;
   policyPath: string;
+  allowArtifacts: boolean;
 }): void {
-  const { policy, policyPath } = args;
+  const { policy, policyPath, allowArtifacts } = args;
   const expected = policy.meta?.prime_directive_sha256;
 
   if (!expected || typeof expected !== "string" || expected.trim().length === 0) {
     throw new Error("Prime Directive pin missing: meta.prime_directive_sha256 must be set.");
   }
 
-  const isLocal = policyPath.includes("artifacts\\local") || policyPath.includes("artifacts/local");
-  const cwd = process.cwd();
-  const primeCandidates = isLocal
-    ? [
-        path.resolve(cwd, "artifacts/local/prime_directive.local.md"),
-        path.resolve(cwd, "..", "artifacts/local/prime_directive.local.md"),
-        "/artifacts/local/prime_directive.local.md",
-      ]
-    : [
-        path.resolve(cwd, "artifacts/policy/default/prime_directive.default.md"),
-        path.resolve(cwd, "..", "artifacts/policy/default/prime_directive.default.md"),
-        "/artifacts/policy/default/prime_directive.default.md",
-      ];
-
-  const primePath = firstExisting(primeCandidates);
+  const primePath = resolvePrimeDirectivePath({ policyPath, allowArtifacts });
   if (!primePath) {
     throw new Error("Prime Directive not found for governance freeze check.");
   }
@@ -106,40 +150,35 @@ function enforcePrimeDirectiveFreeze(args: {
  * Load the policy JSON.
  *
  * Resolution order:
- * 1) artifacts/local/policy.local.json
- * 2) artifacts/policy/default/policy.default.json
- *
- * Supports both:
- * - agent/artifacts/...
- * - repo-root/artifacts/...
+ * 1) POLICY_PATH (explicit file path)
+ * 2) POLICY_DIR (directory with policy.local.json or policy.default.json)
+ * 3) Optional legacy artifacts fallback if ALLOW_ARTIFACTS_READ=true
  */
 export function loadPolicy(): PolicyJson {
-  const cwd = process.cwd();
-  const localCandidates = [
-    path.resolve(cwd, "artifacts/local/policy.local.json"),
-    path.resolve(cwd, "..", "artifacts/local/policy.local.json"),
-    "/artifacts/local/policy.local.json",
-  ];
+  const allowArtifacts = process.env.ALLOW_ARTIFACTS_READ === "true";
+  const envResolved = resolvePolicyPathFromEnv();
 
-  const defaultCandidates = [
-    path.resolve(cwd, "artifacts/policy/default/policy.default.json"),
-    path.resolve(cwd, "..", "artifacts/policy/default/policy.default.json"),
-    "/artifacts/policy/default/policy.default.json",
-  ];
-
-  const localPath = firstExisting(localCandidates);
-  if (localPath) {
-    const policy = readJson<PolicyJson>(localPath);
-    enforcePrimeDirectiveFreeze({ policy, policyPath: localPath });
-    return policy;
+  let policyPath = envResolved;
+  if (!policyPath && allowArtifacts) {
+    const cwd = process.cwd();
+    const legacyCandidates = [
+      path.resolve(cwd, "artifacts/local/policy.local.json"),
+      path.resolve(cwd, "..", "artifacts/local/policy.local.json"),
+      "/artifacts/local/policy.local.json",
+      path.resolve(cwd, "artifacts/policy/default/policy.default.json"),
+      path.resolve(cwd, "..", "artifacts/policy/default/policy.default.json"),
+      "/artifacts/policy/default/policy.default.json",
+    ];
+    policyPath = firstExisting(legacyCandidates);
   }
 
-  const defaultPath = firstExisting(defaultCandidates);
-  if (!defaultPath) {
-    throw new Error("Policy JSON not found (local or default).");
+  if (!policyPath) {
+    throw new Error(
+      "Policy JSON not found. Set POLICY_PATH or POLICY_DIR (or enable ALLOW_ARTIFACTS_READ=true for legacy artifacts)."
+    );
   }
 
-  const policy = readJson<PolicyJson>(defaultPath);
-  enforcePrimeDirectiveFreeze({ policy, policyPath: defaultPath });
+  const policy = readJson<PolicyJson>(policyPath);
+  enforcePrimeDirectiveFreeze({ policy, policyPath, allowArtifacts });
   return policy;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,7 @@
 - **UI / Client:** Collects chat + structured `portfolio_state`, renders chat as supportive UX, and treats Decision Snapshot as authoritative output.
 - **API / Service layer:** `POST /api/chat` validates request shape, orchestrates decision flow, applies guardrails, and emits snapshot.
 - **Data store(s):** File-based policy/config artifacts (`artifacts/policy/default/*`, optional `artifacts/local/*`) are source of truth; no DB through Milestone 3c.
+At runtime, policy must be provided via explicit configuration; repo artifacts are not valid runtime dependencies.
 - **Integrations:** LLM generation via Mastra agent abstraction; policy and explanation contract loaded from artifacts.
 - **Jobs / schedulers (if any):** None in current scope.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -121,5 +121,49 @@
 
 ---
 
+## 2026-02-07 — Iteration M3b (Show Your Work)
+### Added
+- Evaluation fields for policy application (`policy_applied`), deterministic drift (`drift`), and correctness (`correctness`).
+- Contradiction rejection with deterministic fail status and structured error codes.
+- Golden reference snapshots under `artifacts/reference/milestone-3b/` (reference outputs only).
+- Dev-only escape hatch: `ALLOW_ARTIFACTS_READ=true` to permit artifact reads in local/dev scenarios (non-default).
+- Unit tests enforcing “no artifacts read by default” and “missing config fails fast”.
+
+### Changed
+- If `portfolio_state` exists, the system never asks for weights.
+- Deterministic drift and policy application details are now explicit in snapshots.
+- Runtime policy loading now requires explicit configuration via `POLICY_PATH` or `POLICY_DIR`; runtime no longer reads policy directly from repo `artifacts/...`.
+- If no policy source is configured, the service fails fast with a clear runtime error.
+
+### Fixed
+- N/A
+
+### Removed
+- N/A
+
+### Data / Schema
+- Decision Snapshot evaluation section expanded to include policy-applied provenance, drift status, and correctness status.
+
+### Risks / Follow-ups
+- M3c guardrail expansions remain out of scope.
+
+### Manual regression checks (quick)
+- [ ] Portfolio state present → no request for weights; drift status is deterministic.
+- [ ] Contradiction between model output and deterministic expectation yields `correctness=fail`.
+- [ ] Drift evaluation is populated or explicitly marked not applicable/cannot compute.
+- [ ] With no `POLICY_PATH`/`POLICY_DIR`, startup/request fails fast (no silent artifacts fallback).
+- [ ] With `POLICY_PATH` or `POLICY_DIR` set, policy loads successfully and snapshot includes normal policy provenance.
+- [ ] With `ALLOW_ARTIFACTS_READ=true` (dev only), artifact-based policy load is permitted; without it, artifact reads are rejected.
+
+### Tests
+- `cd agent && npm test`
+
+### Paths touched
+- `agent/lib/domain/decisionSnapshot.ts`
+- `agent/lib/services/decisionService.ts`
+- `agent/lib/services/decisionSnapshotContract.m3b.test.ts`
+- `artifacts/reference/milestone-3b/*`
+
+---
 ## Milestone 3c Marker
 Backfilled documentation is complete through Milestone 3c.

--- a/docs/decisions/ADR-0004-disallow-repo-artifacts-as-runtime-policy-dependencies.md
+++ b/docs/decisions/ADR-0004-disallow-repo-artifacts-as-runtime-policy-dependencies.md
@@ -1,0 +1,33 @@
+# Title
+Disallow repo artifacts as runtime policy dependencies
+
+# Status
+Accepted
+
+# Date
+2026-02-07
+
+# Context
+During Milestone 3b hardening, runtime policy loading in policyLoader.ts was found to read policy inputs directly from repo artifacts (artifacts/...).
+This violates the system rule that runtime must not depend on repo artifacts.
+A fix was implemented to remove unconditional artifact reads, require configuration-driven sources, and add tests that cover the new behavior.
+
+# Decision
+Runtime must not read policy/config directly from repo artifacts (artifacts/...).
+Runtime policy sources must be provided explicitly via POLICY_PATH or POLICY_DIR.
+If no policy source is configured, the system fails fast with a clear runtime error.
+A dev-only escape hatch (ALLOW_ARTIFACTS_READ=true) may exist but must be explicitly gated and non-default.
+Artifacts under artifacts/policy/default/* remain immutable and are not altered by this decision.
+
+# Consequences
+- Deployments must provide POLICY_PATH or POLICY_DIR for policy loading.
+- Missing or misconfigured policy sources fail fast at runtime with a clear error.
+- Local development can opt-in to legacy artifact reads only via an explicit flag.
+
+# Alternatives considered
+- Continue reading artifacts at runtime (rejected: violates the runtime/artifact boundary).
+- Bundle policy into build output (rejected/deferred: adds build-time coupling and distribution complexity).
+
+# Notes / Links
+- agent/lib/infra/policyLoader.ts
+- agent/lib/infra/policyLoader.test.ts


### PR DESCRIPTION
## Summary
- Enforce runtime policy loading via POLICY_PATH/POLICY_DIR; remove default artifact reads
- Add dev-only legacy fallback gate (ALLOW_ARTIFACTS_READ=true)
- Add unit tests for policyLoader boundary behavior
- Update docs (ADR, Architecture sentence, CHANGELOG entry)

## Evidence
- Runtime boundary: agent/lib/infra/policyLoader.ts
- Tests: agent/lib/infra/policyLoader.test.ts
- ADR: docs/decisions/ADR-0004-disallow-repo-artifacts-as-runtime-policy-dependencies.md
- Docs updates: docs/ARCHITECTURE.md, docs/CHANGELOG.md

## Tests
- cd agent && npm test

## Closure Comment
Runtime policy loading boundary hardening complete.

Evidence:
- Runtime policy loading now resolves exclusively via POLICY_PATH or POLICY_DIR in agent/lib/infra/policyLoader.ts.
- Unconditional runtime reads from artifacts/... removed.
- Dev-only legacy fallback gated behind ALLOW_ARTIFACTS_READ=true.
- Clear runtime error raised when no policy source is configured.
- Deterministic unit tests added: agent/lib/infra/policyLoader.test.ts.

Scope confirmation:
- No changes to policy content or structure.
- No changes under artifacts/policy/default (M1/M2 artefacts remain immutable).
- No behavioural, correctness, or guardrail logic added.
