### PR TITLE
[M3b] Align scenario docs + integration tests (scenarios 4-5)

### DIFF
--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -332,13 +332,25 @@ describe("runDecision", () => {
         {
           role: "user",
           content:
-            "Evaluate my portfolio against the current investment policy.\n\nPortfolio state:\n- Total value: £100,000\n- Asset allocation:\n  - Equities: 81%\n  - Bonds: 14%\n  - Cash: 5%\n\nThere are no new contributions or withdrawals.\n\nIf action is not justified by policy, explicitly recommend inaction.\nGenerate a decision snapshot.",
+            "Evaluate my portfolio against the current investment policy using the provided portfolio_state. If action is not justified by policy, explicitly recommend inaction. Generate a decision snapshot.",
         },
       ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
       risk_inputs: defaultRiskInputs,
     });
 
+    expect(result.snapshot.outcome_state).toBe("RECOMMEND_NO_ACTION");
     expect(result.snapshot.recommendation.type).toBe("DO_NOTHING");
+    expect(result.snapshot.evaluation.drift.status).toBe("computed");
+    expect(result.snapshot.evaluation.drift_analysis.bands_breached).toBe(false);
   });
 
   it("recommends rebalancing via contributions when in-band with contributions (3c prompt C)", async () => {

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -204,6 +204,34 @@ describe("runDecision", () => {
     expect(result.snapshot.policy_items_referenced.length).toBeGreaterThan(0);
   });
 
+  it("policy provenance includes DPQ ids on an in-band, no-cash-flows decision", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the current investment policy and include policy provenance. Portfolio state: As of date 2026-02-07. Total value: £200,000. Weights: EQUITIES 80%, BONDS 15%, CASH 5%. No new contributions. No new withdrawals. Return a decision snapshot with referenced policy items.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 200000,
+        weights: { EQUITIES: 0.8, BONDS: 0.15, CASH: 0.05 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      risk_inputs: defaultRiskInputs,
+    });
+
+    expect(result.snapshot.outcome_state).toBe("RECOMMEND_NO_ACTION");
+    expect(result.snapshot.policy_items_referenced.length).toBeGreaterThan(0);
+    expect(result.snapshot.policy_items_referenced[0].dpq_id).toMatch(/^DPQ-\d{3}$/);
+    expect(Array.isArray(result.snapshot.warnings)).toBe(true);
+    expect(Array.isArray(result.snapshot.errors)).toBe(true);
+  });
+
   it("recommends rebalance when drift is out of band and no cash flows (scenario 3)", async () => {
     const result = await runDecision({
       messages: [

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -232,6 +232,32 @@ describe("runDecision", () => {
     expect(Array.isArray(result.snapshot.errors)).toBe(true);
   });
 
+  it("in-band, no-cash-flows returns DO_NOTHING with computed drift", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the current investment policy. Portfolio state: Total value: £100,000. Asset allocation: Equities 80%, Bonds 15%, Cash 5%. No new contributions. No new withdrawals. Generate a decision snapshot and recommendation.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.8, BONDS: 0.15, CASH: 0.05 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      risk_inputs: defaultRiskInputs,
+    });
+
+    expect(result.snapshot.outcome_state).toBe("RECOMMEND_NO_ACTION");
+    expect(result.snapshot.recommendation.type).toBe("DO_NOTHING");
+    expect(result.snapshot.evaluation.drift.bands_breached).toBe(false);
+  });
+
   it("recommends rebalance when drift is out of band and no cash flows (scenario 3)", async () => {
     const result = await runDecision({
       messages: [

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -305,13 +305,25 @@ describe("runDecision", () => {
         {
           role: "user",
           content:
-            "Evaluate my portfolio against the current investment policy.\n\nPortfolio state:\n- Total value: £100,000\n- Asset allocation:\n  - Equities: 86%\n  - Bonds: 9%\n  - Cash: 5%\n\nCash flows:\n- Planned contribution: £5,000\n- No withdrawals\n\nGenerate a decision snapshot and recommendation.",
+            "Evaluate my portfolio against the current investment policy using the provided portfolio_state. Generate a decision snapshot and recommendation.",
         },
       ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.88, BONDS: 0.08, CASH: 0.04 },
+        cash_flows: {
+          pending_contributions_gbp: 5000,
+          pending_withdrawals_gbp: 0,
+        },
+      },
       risk_inputs: defaultRiskInputs,
     });
 
+    expect(result.snapshot.outcome_state).toBe("RECOMMEND_ACTION");
     expect(result.snapshot.recommendation.type).toBe("REBALANCE_VIA_CONTRIBUTIONS");
+    expect(result.snapshot.evaluation.drift.status).toBe("computed");
+    expect(result.snapshot.evaluation.drift_analysis.bands_breached).toBe(true);
   });
 
   it("overrides temptation to act when drift is in band with no cash flows (scenario 5)", async () => {

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -177,6 +177,33 @@ describe("runDecision", () => {
     });
   });
 
+  it("scenario 2 (in-band, no cash flows) returns RECOMMEND_NO_ACTION", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the current investment policy. Portfolio state: As of date 2026-02-07. Total value: £100,000. Weights: EQUITIES 80%, BONDS 15%, CASH 5%. No new contributions. No new withdrawals. Generate a decision snapshot and recommendation.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.8, BONDS: 0.15, CASH: 0.05 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      risk_inputs: defaultRiskInputs,
+    });
+
+    expect(result.snapshot.outcome_state).toBe("RECOMMEND_NO_ACTION");
+    expect(result.snapshot.recommendation.type).toBe("DO_NOTHING");
+    expect(result.snapshot.inputs_missing).toEqual([]);
+    expect(result.snapshot.policy_items_referenced.length).toBeGreaterThan(0);
+  });
+
   it("recommends rebalance when drift is out of band and no cash flows (scenario 3)", async () => {
     const result = await runDecision({
       messages: [

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -258,6 +258,32 @@ describe("runDecision", () => {
     expect(result.snapshot.evaluation.drift.bands_breached).toBe(false);
   });
 
+  it("out-of-band overweight returns REBALANCE with bands breached", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the current investment policy. Portfolio state: Total value £100,000. Asset allocation: Equities 88%, Bonds 8%, Cash 4%. No new contributions. No new withdrawals. Generate a decision snapshot and recommendation.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.88, BONDS: 0.08, CASH: 0.04 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      risk_inputs: defaultRiskInputs,
+    });
+
+    expect(result.snapshot.outcome_state).toBe("RECOMMEND_ACTION");
+    expect(result.snapshot.recommendation.type).toBe("REBALANCE");
+    expect(result.snapshot.evaluation.drift.bands_breached).toBe(true);
+  });
+
   it("recommends rebalance when drift is out of band and no cash flows (scenario 3)", async () => {
     const result = await runDecision({
       messages: [

--- a/docs/reference/tests/milestone-3b/SCENARIO_4_CONTRIBUTION.md
+++ b/docs/reference/tests/milestone-3b/SCENARIO_4_CONTRIBUTION.md
@@ -1,36 +1,53 @@
 ---
-> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+> ?? **NON-AUTHORITATIVE REFERENCE**
 >
 > This document is supporting material and is **not** a source of truth.
 > The authoritative docs are:
-> - `docs/ARCHITECTURE.md`
-> - `docs/CHANGELOG.md`
-> - `docs/decisions/` (ADR-lite)
+> - docs/ARCHITECTURE.md
+> - docs/CHANGELOG.md
+> - docs/decisions/ (ADR-lite)
 >
 > If this document conflicts with code or ADRs, treat this document as outdated.
 ---
-# Scenario 4 — Out-of-Band Drift With New Contribution
+# Scenario 4 � Out-of-Band Drift With New Contribution
 
 **(Expected: REBALANCE_VIA_CONTRIBUTIONS)**
 
 **Prompt:**
 
-```
-Evaluate my portfolio against the current investment policy.
+`
+Evaluate my portfolio against the current investment policy using the provided
+portfolio_state. Generate a decision snapshot and recommendation.
+`
 
-Portfolio state:
-- Total value: £100,000
-- Asset allocation:
-  - Equities: 84%
-  - Bonds: 11%
-  - Cash: 5%
+**API Call (PowerShell):**
 
-Cash flows:
-- Planned contribution: £5,000
-- No new withdrawals
+`powershell
+ = @{
+  messages = @(
+    @{ role =  user; content = Evaluate my portfolio against the current investment policy using the provided portfolio_state. Generate a decision snapshot and recommendation. }
+  )
+  portfolio_state = @{
+    as_of_date = 2026-02-07
+    total_value_gbp = 100000
+    weights = @{ EQUITIES = 0.88; BONDS = 0.08; CASH = 0.04 }
+    cash_flows = @{ pending_contributions_gbp = 5000; pending_withdrawals_gbp = 0 }
+  }
+  risk_inputs = @{
+    rolling_12m_drawdown_pct = 0.10
+    risk_capacity_breached = False
+  }
+} | ConvertTo-Json -Depth 10
 
-Generate a decision snapshot and recommendation.
-```
+Invoke-RestMethod -Method Post -Uri http://localhost:3000/api/chat -ContentType application/json -Body 
+`
+
+**Expected Outcomes:**
+
+- snapshot.outcome_state is RECOMMEND_ACTION
+- snapshot.recommendation.type is REBALANCE_VIA_CONTRIBUTIONS
+- snapshot.evaluation.drift.status is computed
+- snapshot.evaluation.drift_analysis.bands_breached is 	rue
 
 **What this tests**
 

--- a/docs/reference/tests/milestone-3b/SCENARIO_5_GUARDRAIL_OVERRIDE.md
+++ b/docs/reference/tests/milestone-3b/SCENARIO_5_GUARDRAIL_OVERRIDE.md
@@ -1,40 +1,58 @@
 ---
-> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+> ?? **NON-AUTHORITATIVE REFERENCE**
 >
 > This document is supporting material and is **not** a source of truth.
 > The authoritative docs are:
-> - `docs/ARCHITECTURE.md`
-> - `docs/CHANGELOG.md`
-> - `docs/decisions/` (ADR-lite)
+> - docs/ARCHITECTURE.md
+> - docs/CHANGELOG.md
+> - docs/decisions/ (ADR-lite)
 >
 > If this document conflicts with code or ADRs, treat this document as outdated.
 ---
-# Scenario 5 — In-Band Drift but Tempting to Act
+# Scenario 5 � In-Band Drift but Tempting to Act
 
 **(Guardrail: Override to DO_NOTHING / DEFER)**
 
 **Prompt:**
 
-```
-Evaluate my portfolio against the current investment policy.
+`
+Evaluate my portfolio against the current investment policy using the provided
+portfolio_state. If action is not justified by policy, explicitly recommend
+inaction. Generate a decision snapshot.
+`
 
-Portfolio state:
-- Total value: £100,000
-- Asset allocation:
-  - Equities: 62%
-  - Bonds: 33%
-  - Cash: 5%
+**API Call (PowerShell):**
 
-No new contributions.
-No new withdrawals.
+`powershell
+ = @{
+  messages = @(
+    @{ role =  user; content = Evaluate my portfolio against the current investment policy using the provided portfolio_state. If action is not justified by policy, explicitly recommend inaction. Generate a decision snapshot. }
+  )
+  portfolio_state = @{
+    as_of_date = 2026-02-07
+    total_value_gbp = 100000
+    weights = @{ EQUITIES = 0.62; BONDS = 0.33; CASH = 0.05 }
+    cash_flows = @{ pending_contributions_gbp = 0; pending_withdrawals_gbp = 0 }
+  }
+  risk_inputs = @{
+    rolling_12m_drawdown_pct = 0.10
+    risk_capacity_breached = False
+  }
+} | ConvertTo-Json -Depth 10
 
-If action is not justified by policy, explicitly recommend inaction.
-Generate a decision snapshot.
-```
+Invoke-RestMethod -Method Post -Uri http://localhost:3000/api/chat -ContentType application/json -Body 
+`
+
+**Expected Outcomes:**
+
+- snapshot.outcome_state is RECOMMEND_NO_ACTION
+- snapshot.recommendation.type is DO_NOTHING
+- snapshot.evaluation.drift.status is computed
+- snapshot.evaluation.drift_analysis.bands_breached is alse
 
 **What this tests**
 
-* Guardrails overriding “helpful” but unnecessary action
+* Guardrails overriding helpful but unnecessary action
 * Discipline over optimisation theatre
 
 ---


### PR DESCRIPTION
## Summary
- Update M3b scenario docs to use structured portfolio_state inputs (scenarios 4-5)
- Align integration tests for contribution rebalance and in-band guardrail override
- Preserve deterministic outcomes and drift assertions

## Tests
- cd agent && npm test