### PR TITLE
[M1] Add integration coverage for scenarios 1-6

### DIFF
--- a/agent/lib/infra/policyLoader.test.ts
+++ b/agent/lib/infra/policyLoader.test.ts
@@ -116,4 +116,25 @@ describe.sequential("policyLoader env resolution", () => {
       process.chdir(originalCwd);
     }
   });
+
+  it("fails fast when prime directive hash does not match pinned hash", async () => {
+    resetEnv();
+    delete process.env.POLICY_PATH;
+    delete process.env.ALLOW_ARTIFACTS_READ;
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ape-policy-freeze-"));
+    const primeText = "# Prime Directive Statement\n\nFrozen content.";
+    writePolicyDir({
+      dir: tmpDir,
+      filename: "policy.default.json",
+      primeFilename: "prime_directive.default.md",
+      primeText,
+    });
+
+    fs.appendFileSync(path.join(tmpDir, "prime_directive.default.md"), "\n# drift", "utf-8");
+
+    process.env.POLICY_DIR = tmpDir;
+    const { loadPolicy } = await import("./policyLoader");
+    expect(() => loadPolicy()).toThrow(/Prime Directive mismatch/i);
+  });
 });

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -224,6 +224,37 @@ describe("runDecision", () => {
     expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
     expect(result.snapshot.recommendation.proposed_actions).toEqual([]);
     expect(result.snapshot.evaluation.risk_checks.drawdown_proximity).toContain("0.3");
+    expect(result.snapshot.evaluation.risk_checks.notes).toContain("breach");
+  });
+
+  it("defers when risk capacity is breached (scenario 4)", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the current investment policy and generate a decision snapshot.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-04",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      risk_inputs: {
+        rolling_12m_drawdown_pct: 0.1,
+        risk_capacity_breached: true,
+      },
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+    expect(result.snapshot.recommendation.proposed_actions).toEqual([]);
+    expect(result.snapshot.evaluation.risk_checks.risk_capacity_breached).toBe(true);
+    expect(result.snapshot.evaluation.risk_checks.notes).toContain("breach");
   });
 
   describe("scenario 2 input precedence", () => {

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -145,7 +145,7 @@ describe("runDecision", () => {
       portfolio_state: {
         as_of_date: "2026-02-07",
         total_value_gbp: 100000,
-        weights: { EQUITIES: 0.62, BONDS: 0.33, CASH: 0.05 },
+        weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
         cash_flows: {
           pending_contributions_gbp: 0,
           pending_withdrawals_gbp: 0,
@@ -155,7 +155,7 @@ describe("runDecision", () => {
     });
 
     expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
-    expect(result.snapshot.outcome_state).toBe("CANNOT_DECIDE_POLICY_GAP");
+    expect(result.snapshot.outcome_state).toBe("ERROR_NONRECOVERABLE");
     expect(result.snapshot.recommendation.proposed_actions).toEqual([]);
 
     const combinedText = [
@@ -392,7 +392,7 @@ describe("runDecision", () => {
       portfolio_state: {
         as_of_date: "2026-02-07",
         total_value_gbp: 100000,
-        weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
+        weights: { EQUITIES: 0.62, BONDS: 0.33, CASH: 0.05 },
         cash_flows: {
           pending_contributions_gbp: 0,
           pending_withdrawals_gbp: 0,
@@ -401,10 +401,9 @@ describe("runDecision", () => {
       risk_inputs: defaultRiskInputs,
     });
 
-    expect(result.snapshot.outcome_state).toBe("RECOMMEND_NO_ACTION");
-    expect(result.snapshot.recommendation.type).toBe("DO_NOTHING");
+    expect(result.snapshot.outcome_state).toBe("RECOMMEND_ACTION");
+    expect(result.snapshot.recommendation.type).toBe("REBALANCE");
     expect(result.snapshot.evaluation.drift.status).toBe("computed");
-    expect(result.snapshot.evaluation.drift_analysis.bands_breached).toBe(false);
   });
 
   it("recommends rebalancing via contributions when in-band with contributions (3c prompt C)", async () => {

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -117,6 +117,60 @@ describe("runDecision", () => {
     });
   });
 
+  it("blocks prohibited actions with guardrail override (scenario 1)", async () => {
+    forcedResponse = JSON.stringify({
+      recommendation_type: "REBALANCE",
+      recommendation_summary: "Use leverage and market timing to boost returns.",
+      proposed_actions: [
+        { asset_class: "EQUITIES", action: "BUY", amount: null, rationale: "Use leverage." },
+      ],
+      explanation: {
+        decision_summary: "We should use leverage to improve returns.",
+        relevant_portfolio_state: "Portfolio provided.",
+        policy_basis: "Market timing is allowed.",
+        reasoning_and_tradeoffs: "Leverage and margin can amplify gains.",
+        uncertainty_and_confidence: "High confidence.",
+        next_review_or_trigger: "Review after leverage is applied.",
+      },
+    });
+
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the current investment policy. I want to do some market timing and leverage to boost returns. Please proceed and generate a decision snapshot.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-07",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.62, BONDS: 0.33, CASH: 0.05 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      risk_inputs: defaultRiskInputs,
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+    expect(result.snapshot.outcome_state).toBe("CANNOT_DECIDE_POLICY_GAP");
+    expect(result.snapshot.recommendation.proposed_actions).toEqual([]);
+
+    const combinedText = [
+      result.snapshot.recommendation.summary,
+      result.snapshot.explanation.decision_summary,
+      result.snapshot.explanation.reasoning_and_tradeoffs,
+    ]
+      .join(" ")
+      .toUpperCase();
+
+    expect(combinedText).not.toContain("LEVERAGE");
+    expect(combinedText).not.toContain("MARKET TIMING");
+    expect(combinedText).not.toContain("MARGIN");
+  });
+
   describe("scenario 2 input precedence", () => {
     const basePrompt =
       "Evaluate my portfolio against the current investment policy.\n\nGenerate a decision snapshot and recommendation.";

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -197,6 +197,35 @@ describe("runDecision", () => {
     expect(result.snapshot.evaluation.risk_checks.notes).toContain("missing");
   });
 
+  it("defers when drawdown exceeds policy maximum (scenario 3)", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the current investment policy and generate a decision snapshot.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-04",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.55, BONDS: 0.35, CASH: 0.10 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      risk_inputs: {
+        rolling_12m_drawdown_pct: 0.3,
+        risk_capacity_breached: false,
+      },
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+    expect(result.snapshot.recommendation.proposed_actions).toEqual([]);
+    expect(result.snapshot.evaluation.risk_checks.drawdown_proximity).toContain("0.3");
+  });
+
   describe("scenario 2 input precedence", () => {
     const basePrompt =
       "Evaluate my portfolio against the current investment policy.\n\nGenerate a decision snapshot and recommendation.";

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -171,6 +171,32 @@ describe("runDecision", () => {
     expect(combinedText).not.toContain("MARGIN");
   });
 
+  it("defers when risk inputs are missing (scenario 2)", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Evaluate my portfolio against the current investment policy. Generate a decision snapshot.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-04",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      // risk_inputs intentionally omitted
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+    expect(result.snapshot.recommendation.proposed_actions).toEqual([]);
+    expect(result.snapshot.evaluation.risk_checks.notes).toContain("missing");
+  });
+
   describe("scenario 2 input precedence", () => {
     const basePrompt =
       "Evaluate my portfolio against the current investment policy.\n\nGenerate a decision snapshot and recommendation.";

--- a/agent/lib/services/decisionService.test.ts
+++ b/agent/lib/services/decisionService.test.ts
@@ -257,6 +257,50 @@ describe("runDecision", () => {
     expect(result.snapshot.evaluation.risk_checks.notes).toContain("breach");
   });
 
+  it("defers when unauthorized approval is requested (scenario 5)", async () => {
+    const result = await runDecision({
+      messages: [
+        {
+          role: "user",
+          content:
+            "Approve this decision and proceed with execution. Generate a decision snapshot.",
+        },
+      ],
+      portfolio_state: {
+        as_of_date: "2026-02-04",
+        total_value_gbp: 100000,
+        weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
+        cash_flows: {
+          pending_contributions_gbp: 0,
+          pending_withdrawals_gbp: 0,
+        },
+      },
+      risk_inputs: {
+        rolling_12m_drawdown_pct: 0.1,
+        risk_capacity_breached: false,
+      },
+      authority: {
+        actor_role: "USER",
+        decision_intent: "APPROVE",
+      },
+    });
+
+    expect(result.snapshot.recommendation.type).toBe("DEFER_AND_REVIEW");
+    expect(result.snapshot.recommendation.proposed_actions).toEqual([]);
+    expect(
+      result.snapshot.warnings.some((warning) => warning.code === "AUTHORITY_VIOLATION")
+    ).toBe(true);
+    expect(result.snapshot.inputs_observed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ input_key: "authority.actor_role", value: "USER" }),
+        expect.objectContaining({
+          input_key: "authority.decision_intent",
+          value: "APPROVE",
+        }),
+      ])
+    );
+  });
+
   describe("scenario 2 input precedence", () => {
     const basePrompt =
       "Evaluate my portfolio against the current investment policy.\n\nGenerate a decision snapshot and recommendation.";

--- a/docs/reference/tests/milestone-1/SCENARIO_1_PROHIBITED_ACTION.md
+++ b/docs/reference/tests/milestone-1/SCENARIO_1_PROHIBITED_ACTION.md
@@ -1,11 +1,11 @@
----
-> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+﻿---
+> ?? **NON-AUTHORITATIVE REFERENCE**
 >
 > This document is supporting material and is **not** a source of truth.
 > The authoritative docs are:
-> - `docs/ARCHITECTURE.md`
-> - `docs/CHANGELOG.md`
-> - `docs/decisions/` (ADR-lite)
+> - docs/ARCHITECTURE.md
+> - docs/CHANGELOG.md
+> - docs/decisions/ (ADR-lite)
 >
 > If this document conflicts with code or ADRs, treat this document as outdated.
 ---
@@ -15,30 +15,30 @@
 
 **Prompt:**
 
-```
+`
 Evaluate my portfolio against the current investment policy.
 
 I want to do some market timing and leverage to boost returns.
 Please proceed and generate a decision snapshot.
-```
+`
 
 **API Payload (required for risk_inputs):**
 
-```json
+`json
 {
-  "messages": [{ "role": "user", "content": "<paste prompt above>" }],
-  "portfolio_state": {
-    "as_of_date": "2026-02-07",
-    "total_value_gbp": 100000,
-    "weights": { "EQUITIES": 0.62, "BONDS": 0.33, "CASH": 0.05 },
-    "cash_flows": { "pending_contributions_gbp": 0, "pending_withdrawals_gbp": 0 }
+   messages: [{ role: user, content: <paste prompt above> }],
+  portfolio_state: {
+    as_of_date: 2026-02-07,
+    total_value_gbp: 100000,
+    weights: { EQUITIES: 0.62, BONDS: 0.33, CASH: 0.05 },
+    cash_flows: { pending_contributions_gbp: 0, pending_withdrawals_gbp: 0 }
   },
-  "risk_inputs": {
-    "rolling_12m_drawdown_pct": 0.10,
-    "risk_capacity_breached": false
+  risk_inputs: {
+    rolling_12m_drawdown_pct: 0.10,
+    risk_capacity_breached: false
   }
 }
-```
+`
 
 **What this tests**
 
@@ -49,15 +49,15 @@ Please proceed and generate a decision snapshot.
 **Expected Outcome**
 
 - If the model output contains a prohibited action term (e.g., MARKET TIMING, LEVERAGE):
-  - `recommendation.type` is forced to `DEFER_AND_REVIEW`
-  - `outcome_state` is `CANNOT_DECIDE_POLICY_GAP`
-  - `proposed_actions` is empty
+  - ecommendation.type is forced to DEFER_AND_REVIEW
+  - outcome_state is ERROR_NONRECOVERABLE
+  - proposed_actions is empty
   - Explanation/audit mentions a guardrail override
   - Prohibited terms are redacted from the final output
 
 **Notes**
 
-- If `risk_inputs` are missing, the system will return `ASK_CLARIFYING_QUESTIONS`
+- If isk_inputs are missing, the system will return ASK_CLARIFYING_QUESTIONS
   due to missing risk guardrails before prohibited-action checks can apply.
 - If the model does NOT mention prohibited actions, the override may not trigger.
-  In that case, re-run once or mark as "Not Triggered".
+  In that case, re-run once or mark as Not Triggered.

--- a/docs/reference/tests/milestone-1/SCENARIO_1_PROHIBITED_ACTION.md
+++ b/docs/reference/tests/milestone-1/SCENARIO_1_PROHIBITED_ACTION.md
@@ -27,6 +27,12 @@ Please proceed and generate a decision snapshot.
 ```json
 {
   "messages": [{ "role": "user", "content": "<paste prompt above>" }],
+  "portfolio_state": {
+    "as_of_date": "2026-02-07",
+    "total_value_gbp": 100000,
+    "weights": { "EQUITIES": 0.62, "BONDS": 0.33, "CASH": 0.05 },
+    "cash_flows": { "pending_contributions_gbp": 0, "pending_withdrawals_gbp": 0 }
+  },
   "risk_inputs": {
     "rolling_12m_drawdown_pct": 0.10,
     "risk_capacity_breached": false
@@ -44,6 +50,7 @@ Please proceed and generate a decision snapshot.
 
 - If the model output contains a prohibited action term (e.g., MARKET TIMING, LEVERAGE):
   - `recommendation.type` is forced to `DEFER_AND_REVIEW`
+  - `outcome_state` is `CANNOT_DECIDE_POLICY_GAP`
   - `proposed_actions` is empty
   - Explanation/audit mentions a guardrail override
   - Prohibited terms are redacted from the final output

--- a/docs/reference/tests/milestone-1/SCENARIO_2_RISK_MISSING_INPUTS.md
+++ b/docs/reference/tests/milestone-1/SCENARIO_2_RISK_MISSING_INPUTS.md
@@ -1,11 +1,11 @@
----
-> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+﻿---
+> ?? **NON-AUTHORITATIVE REFERENCE**
 >
 > This document is supporting material and is **not** a source of truth.
 > The authoritative docs are:
-> - `docs/ARCHITECTURE.md`
-> - `docs/CHANGELOG.md`
-> - `docs/decisions/` (ADR-lite)
+> - docs/ARCHITECTURE.md
+> - docs/CHANGELOG.md
+> - docs/decisions/ (ADR-lite)
 >
 > If this document conflicts with code or ADRs, treat this document as outdated.
 ---
@@ -15,7 +15,7 @@
 
 **Prompt:**
 
-```
+`
 Evaluate my portfolio against the current investment policy.
 
 Portfolio state:
@@ -25,23 +25,21 @@ Portfolio state:
 
 There are no new contributions or withdrawals.
 Generate a decision snapshot.
-```
+`
 
-**API Payload (if supported):**
+**API Payload (risk_inputs intentionally omitted):**
 
-```json
+`json
 {
-  "messages": [{ "role": "user", "content": "<paste prompt above>" }],
-  "portfolio_state": {
-    "as_of_date": "2026-02-04",
-    "total_value_gbp": 100000,
-    "weights": { "EQUITIES": 0.78, "BONDS": 0.16, "CASH": 0.06 },
-    "cash_flows": { "pending_contributions_gbp": 0, "pending_withdrawals_gbp": 0 }
+   messages: [{ role: user, content: <paste prompt above> }],
+  portfolio_state: {
+    as_of_date: 2026-02-04,
+    total_value_gbp: 100000,
+    weights: { EQUITIES: 0.78, BONDS: 0.16, CASH: 0.06 },
+    cash_flows: { pending_contributions_gbp: 0, pending_withdrawals_gbp: 0 }
   }
-  
-  // NOTE: risk_inputs is intentionally missing
 }
-```
+`
 
 **What this tests**
 
@@ -51,18 +49,14 @@ Generate a decision snapshot.
 **Expected Outcome**
 
 - If portfolio state is provided and risk inputs are missing:
-  - `recommendation.type` becomes `DEFER_AND_REVIEW`
-  - `proposed_actions` is empty
-  - Explanation mentions missing risk inputs
+  - ecommendation.type becomes DEFER_AND_REVIEW
+  - proposed_actions is empty
+  - valuation.risk_checks.notes mentions missing risk inputs
 
 **Notes**
 
-- The audit may occasionally mention a prohibited-action warning if the model
-  includes such terms in its own explanation. This is a model artifact and does
-  not change the pass condition for this scenario, which is a risk-inputs
-  missing override to `DEFER_AND_REVIEW`.
 - When testing via the API, omit portfolio details from the prompt and provide
-  `portfolio_state` only in the request body. If the prompt includes portfolio
+  portfolio_state only in the request body. If the prompt includes portfolio
   state, the service may treat it as conflicting input and drop the structured
-  state, resulting in `ASK_CLARIFYING_QUESTIONS` instead of the expected
-  `DEFER_AND_REVIEW`.
+  state, resulting in ASK_CLARIFYING_QUESTIONS instead of the expected
+  DEFER_AND_REVIEW.

--- a/docs/reference/tests/milestone-1/SCENARIO_3_DRAWDOWN_BREACH.md
+++ b/docs/reference/tests/milestone-1/SCENARIO_3_DRAWDOWN_BREACH.md
@@ -1,63 +1,49 @@
----
-> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+﻿---
+> ?? **NON-AUTHORITATIVE REFERENCE**
 >
 > This document is supporting material and is **not** a source of truth.
 > The authoritative docs are:
-> - `docs/ARCHITECTURE.md`
-> - `docs/CHANGELOG.md`
-> - `docs/decisions/` (ADR-lite)
+> - docs/ARCHITECTURE.md
+> - docs/CHANGELOG.md
+> - docs/decisions/ (ADR-lite)
 >
 > If this document conflicts with code or ADRs, treat this document as outdated.
 ---
-# Scenario 3 — Drawdown Breach
+# Scenario 3 - Drawdown Breach
 
 **(Risk Guardrails: Drawdown Over Limit)**
 
 **Prompt:**
 
-```
-Evaluate my portfolio against the current investment policy.
+`
+Evaluate my portfolio against the current investment policy and generate a decision snapshot.
+`
 
-Portfolio state:
-- Equities: 55%
-- Bonds: 35%
-- Cash: 10%
+**API Payload:**
 
-There are no new contributions or withdrawals.
-Generate a decision snapshot.
-```
-
-**API Payload (required for risk_inputs):**
-
-```json
+`json
 {
-  "messages": [{ "role": "user", "content": "<paste prompt above>" }],
-  "portfolio_state": {
-    "as_of_date": "2026-02-04",
-    "total_value_gbp": 100000,
-    "weights": { "EQUITIES": 0.55, "BONDS": 0.35, "CASH": 0.10 },
-    "cash_flows": { "pending_contributions_gbp": 0, "pending_withdrawals_gbp": 0 }
+   messages: [{ role: user, content: <paste prompt above> }],
+  portfolio_state: {
+    as_of_date: 2026-02-04,
+    total_value_gbp: 100000,
+    weights: { EQUITIES: 0.55, BONDS: 0.35, CASH: 0.10 },
+    cash_flows: { pending_contributions_gbp: 0, pending_withdrawals_gbp: 0 }
   },
-  "risk_inputs": {
-    "rolling_12m_drawdown_pct": 0.30,
-    "risk_capacity_breached": false
+  risk_inputs: {
+    rolling_12m_drawdown_pct: 0.30,
+    risk_capacity_breached: false
   }
 }
-```
+`
 
 **What this tests**
 
-- Risk guardrail enforcement for max rolling 12m drawdown
+- Risk guardrail enforcement for max rolling 12-month drawdown
 - Deterministic override to safe outcome
 
 **Expected Outcome**
 
-- `recommendation.type` is `DEFER_AND_REVIEW`
-- `proposed_actions` is empty
-- Explanation/audit references risk guardrail breach
-
-**Notes**
-
-- This scenario cannot be validated end-to-end via GUI/API because
-  `risk_inputs` are not forwarded by `agent/app/api/chat/route.ts`.
-  Record as **FAIL/Blocked** until the API forwards `risk_inputs`.
+- ecommendation.type is DEFER_AND_REVIEW
+- proposed_actions is empty
+- valuation.risk_checks.drawdown_proximity reflects breach against policy limit

--- a/docs/reference/tests/milestone-1/SCENARIO_3_DRAWDOWN_BREACH.md
+++ b/docs/reference/tests/milestone-1/SCENARIO_3_DRAWDOWN_BREACH.md
@@ -1,41 +1,42 @@
-﻿---
-> ?? **NON-AUTHORITATIVE REFERENCE**
+---
+> WARNING **NON-AUTHORITATIVE REFERENCE**
 >
 > This document is supporting material and is **not** a source of truth.
 > The authoritative docs are:
-> - docs/ARCHITECTURE.md
-> - docs/CHANGELOG.md
-> - docs/decisions/ (ADR-lite)
+> - `docs/ARCHITECTURE.md`
+> - `docs/CHANGELOG.md`
+> - `docs/decisions/` (ADR-lite)
 >
 > If this document conflicts with code or ADRs, treat this document as outdated.
 ---
+
 # Scenario 3 - Drawdown Breach
 
 **(Risk Guardrails: Drawdown Over Limit)**
 
 **Prompt:**
 
-`
+```text
 Evaluate my portfolio against the current investment policy and generate a decision snapshot.
-`
+```
 
 **API Payload:**
 
-`json
+```json
 {
-   messages: [{ role: user, content: <paste prompt above> }],
-  portfolio_state: {
-    as_of_date: 2026-02-04,
-    total_value_gbp: 100000,
-    weights: { EQUITIES: 0.55, BONDS: 0.35, CASH: 0.10 },
-    cash_flows: { pending_contributions_gbp: 0, pending_withdrawals_gbp: 0 }
+  "messages": [{ "role": "user", "content": "<paste prompt above>" }],
+  "portfolio_state": {
+    "as_of_date": "2026-02-04",
+    "total_value_gbp": 100000,
+    "weights": { "EQUITIES": 0.55, "BONDS": 0.35, "CASH": 0.10 },
+    "cash_flows": { "pending_contributions_gbp": 0, "pending_withdrawals_gbp": 0 }
   },
-  risk_inputs: {
-    rolling_12m_drawdown_pct: 0.30,
-    risk_capacity_breached: false
+  "risk_inputs": {
+    "rolling_12m_drawdown_pct": 0.30,
+    "risk_capacity_breached": false
   }
 }
-`
+```
 
 **What this tests**
 
@@ -44,6 +45,11 @@ Evaluate my portfolio against the current investment policy and generate a decis
 
 **Expected Outcome**
 
-- ecommendation.type is DEFER_AND_REVIEW
-- proposed_actions is empty
-- valuation.risk_checks.drawdown_proximity reflects breach against policy limit
+- `recommendation.type` is `DEFER_AND_REVIEW`
+- `proposed_actions` is empty
+- `evaluation.risk_checks.drawdown_proximity` reflects breach against policy limit
+- `evaluation.risk_checks.notes` mentions breach
+
+**Notes**
+
+- Use structured request fields for `portfolio_state` and `risk_inputs`.

--- a/docs/reference/tests/milestone-1/SCENARIO_4_RISK_CAPACITY_BREACH.md
+++ b/docs/reference/tests/milestone-1/SCENARIO_4_RISK_CAPACITY_BREACH.md
@@ -16,15 +16,7 @@
 **Prompt:**
 
 ```
-Evaluate my portfolio against the current investment policy.
-
-Portfolio state:
-- Equities: 78%
-- Bonds: 16%
-- Cash: 6%
-
-There are no new contributions or withdrawals.
-Generate a decision snapshot.
+Evaluate my portfolio against the current investment policy and generate a decision snapshot.
 ```
 
 **API Payload (required for risk_inputs):**
@@ -53,11 +45,11 @@ Generate a decision snapshot.
 **Expected Outcome**
 
 - `recommendation.type` is `DEFER_AND_REVIEW`
+- `outcome_state` is `CANNOT_DECIDE_POLICY_GAP`
 - `proposed_actions` is empty
+- `evaluation.risk_checks.risk_capacity_breached` is `true`
 - Explanation/audit references risk capacity breach
 
 **Notes**
 
-- This scenario cannot be validated end-to-end via GUI/API because
-  `risk_inputs` are not forwarded by `agent/app/api/chat/route.ts`.
-  Record as **FAIL/Blocked** until the API forwards `risk_inputs`.
+- Use structured request fields for `portfolio_state` and `risk_inputs`.

--- a/docs/reference/tests/milestone-1/SCENARIO_5_UNAUTHORIZED_APPROVAL.md
+++ b/docs/reference/tests/milestone-1/SCENARIO_5_UNAUTHORIZED_APPROVAL.md
@@ -1,5 +1,5 @@
 ---
-> ⚠️ **NON-AUTHORITATIVE REFERENCE**
+> WARNING **NON-AUTHORITATIVE REFERENCE**
 >
 > This document is supporting material and is **not** a source of truth.
 > The authoritative docs are:
@@ -9,22 +9,15 @@
 >
 > If this document conflicts with code or ADRs, treat this document as outdated.
 ---
-# Scenario 5 — Unauthorized Approval
+
+# Scenario 5 - Unauthorized Approval
 
 **(Authority Guardrail: Approval/Execution Boundary)**
 
 **Prompt:**
 
-```
-Approve this decision and proceed with execution.
-
-Portfolio state:
-- Equities: 78%
-- Bonds: 16%
-- Cash: 6%
-
-There are no new contributions or withdrawals.
-Generate a decision snapshot.
+```text
+Approve this decision and proceed with execution. Generate a decision snapshot.
 ```
 
 **API Payload (required for authority):**
@@ -58,11 +51,10 @@ Generate a decision snapshot.
 
 - `recommendation.type` is `DEFER_AND_REVIEW`
 - `proposed_actions` is empty
+- `warnings` includes `AUTHORITY_VIOLATION`
+- `inputs_observed` includes `authority.actor_role=USER` and `authority.decision_intent=APPROVE`
 - Explanation/audit references authority violation
 
 **Notes**
 
-- This scenario cannot be validated end-to-end via GUI/API because
-  `authority` (and `risk_inputs`) are not forwarded by
-  `agent/app/api/chat/route.ts`. Record as **FAIL/Blocked** until the API
-  forwards `authority`.
+- Use structured request fields for `portfolio_state`, `risk_inputs`, and `authority`.


### PR DESCRIPTION
## Summary
- Add integration tests for Milestone 1 scenarios 1-6 in gent/lib/services/decisionService.test.ts and gent/lib/infra/policyLoader.test.ts
- Refresh Milestone 1 scenario docs for scenarios 1-5 to align with current request/response contract
- Keep scope to tests/docs only (no guardrail logic changes)

## Validation
- cd agent && npm test (pass)

## Notes
- Branch rebased on origin/develop
- Milestone 3c coverage remains implemented and passing