### PR TITLE
chore(ci): APE-31 enforce branch naming conventions

### DIFF
--- a/.github/workflows/commit-prefix.yml
+++ b/.github/workflows/commit-prefix.yml
@@ -4,6 +4,37 @@ on:
   pull_request:
 
 jobs:
+  branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce branch naming convention
+        shell: bash
+        run: |
+          branch="${{ github.head_ref }}"
+          regex='^(feat|fix|chore|docs|refactor|test|ci|build|perf|style|hotfix)/APE-?[0-9]{1,3}-[a-z0-9][a-z0-9-]*$'
+
+          echo "Validating branch: $branch"
+          echo "$branch" | grep -Eq "$regex" || {
+            cat <<'EOF'
+Branch name is invalid.
+
+Required format:
+  <type>/APE<id>-<description>
+  <type>/APE-<id>-<description>
+
+Rules:
+  - <type> must be one of: feat, fix, chore, docs, refactor, test, ci, build, perf, style, hotfix
+  - <id> must be 1 to 3 digits
+  - <description> must be lowercase kebab-case
+
+Examples:
+  feat/APE1-plane-sync
+  chore/APE-11-update-workflow
+  docs/APE-111-add-setup-guide
+EOF
+            exit 1
+          }
+
   commit-prefix:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,8 @@ artifacts/**/*.pdf
 
 # Local-only Codex/LLM handover notes (do not commit)
 artifacts/.codex/
+
+############################################
+# IDE local MCP config
+############################################
+.vscode/mcp.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,26 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+branch="$(git rev-parse --abbrev-ref HEAD)"
+regex='^(feat|fix|chore|docs|refactor|test|ci|build|perf|style|hotfix)/APE-?[0-9]{1,3}-[a-z0-9][a-z0-9-]*$'
+
+if [ "$branch" != "HEAD" ]; then
+  echo "$branch" | grep -Eq "$regex" || {
+    cat <<'EOF'
+Commit blocked: invalid branch name.
+
+Required format:
+  <type>/APE<id>-<description>
+  <type>/APE-<id>-<description>
+
+Examples:
+  feat/APE1-plane-sync
+  chore/APE-11-update-workflow
+  docs/APE-111-add-setup-guide
+EOF
+    exit 1
+  }
+fi
+
 cd agent || exit 1
 npm run test

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Then browse to:
 
 * This repository follows the Conventional Commits Specification for commits and pull requests.
 * Run unit tests from the `agent/` directory: `npm run test`
+* Branch names are enforced in CI and must follow:
+  * `<type>/APE<id>-<description>` or `<type>/APE-<id>-<description>`
+  * Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`, `build`, `perf`, `style`, `hotfix`
+  * `<id>` must be 1-3 digits, `<description>` must be lowercase kebab-case
+  * Examples: `feat/APE1-plane-sync`, `chore/APE-11-update-workflow`, `docs/APE-111-add-setup-guide`
 * Plane key required in commit subject for code changes: include `APE-<id>` (e.g., `APE-123`).
 * Example: `feat(agent): APE-123 Enforce explanation contract`
 * Docs-only changes (docs/ or *.md only) do not require a Plane key.


### PR DESCRIPTION
## Summary
- add CI validation for branch names on pull requests
- add local pre-commit branch-name validation with the same regex
- document the branch naming convention in README

## Validation
- npm run test (agent)
