### PR TITLE
feat(agent): APE-32 introduce user context abstraction

### DIFF
--- a/agent/lib/user/LocalUserContextProvider.test.ts
+++ b/agent/lib/user/LocalUserContextProvider.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { DEFAULT_LOCAL_USER, LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
+
+const provider = new LocalUserContextProvider();
+
+describe("LocalUserContextProvider", () => {
+  let originalDefaultUserId: string | undefined;
+  let originalDefaultUserName: string | undefined;
+
+  beforeEach(() => {
+    originalDefaultUserId = process.env.DEFAULT_USER_ID;
+    originalDefaultUserName = process.env.DEFAULT_USER_NAME;
+  });
+
+  afterEach(() => {
+    if (originalDefaultUserId === undefined) {
+      delete process.env.DEFAULT_USER_ID;
+    } else {
+      process.env.DEFAULT_USER_ID = originalDefaultUserId;
+    }
+
+    if (originalDefaultUserName === undefined) {
+      delete process.env.DEFAULT_USER_NAME;
+    } else {
+      process.env.DEFAULT_USER_NAME = originalDefaultUserName;
+    }
+  });
+
+  it("returns default local user when env vars are not set", () => {
+    delete process.env.DEFAULT_USER_ID;
+    delete process.env.DEFAULT_USER_NAME;
+
+    expect(provider.getCurrentUser()).toEqual(DEFAULT_LOCAL_USER);
+  });
+
+  it("overrides user id and display name from env vars", () => {
+    process.env.DEFAULT_USER_ID = "custom-user";
+    process.env.DEFAULT_USER_NAME = "Custom Name";
+
+    expect(provider.getCurrentUser()).toEqual({
+      userId: "custom-user",
+      displayName: "Custom Name",
+      authType: DEFAULT_LOCAL_USER.authType,
+    });
+  });
+
+  it("falls back to defaults when env vars are blank", () => {
+    process.env.DEFAULT_USER_ID = "   ";
+    process.env.DEFAULT_USER_NAME = "";
+
+    expect(provider.getCurrentUser()).toEqual(DEFAULT_LOCAL_USER);
+  });
+});

--- a/agent/lib/user/LocalUserContextProvider.test.ts
+++ b/agent/lib/user/LocalUserContextProvider.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { DEFAULT_LOCAL_USER, LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
+import type { User } from "@/lib/user/types";
 
 const provider = new LocalUserContextProvider();
 
@@ -27,14 +28,39 @@ describe("LocalUserContextProvider", () => {
     }
   });
 
-  it("returns default local user when env vars are not set", () => {
-    delete process.env.DEFAULT_USER_ID;
-    delete process.env.DEFAULT_USER_NAME;
+  it("getCurrentUser returns consistent results", () => {
+    process.env.DEFAULT_USER_ID = "consistent-user";
+    process.env.DEFAULT_USER_NAME = "Consistent User";
 
-    expect(provider.getCurrentUser()).toEqual(DEFAULT_LOCAL_USER);
+    const first = provider.getCurrentUser();
+    const second = provider.getCurrentUser();
+
+    expect(first).toEqual(second);
   });
 
-  it("overrides user id and display name from env vars", () => {
+  it("respects DEFAULT_USER_ID override", () => {
+    process.env.DEFAULT_USER_ID = "user-123";
+    delete process.env.DEFAULT_USER_NAME;
+
+    expect(provider.getCurrentUser()).toEqual({
+      userId: "user-123",
+      displayName: DEFAULT_LOCAL_USER.displayName,
+      authType: DEFAULT_LOCAL_USER.authType,
+    });
+  });
+
+  it("respects DEFAULT_USER_NAME override", () => {
+    delete process.env.DEFAULT_USER_ID;
+    process.env.DEFAULT_USER_NAME = "Jane Doe";
+
+    expect(provider.getCurrentUser()).toEqual({
+      userId: DEFAULT_LOCAL_USER.userId,
+      displayName: "Jane Doe",
+      authType: DEFAULT_LOCAL_USER.authType,
+    });
+  });
+
+  it("respects both DEFAULT_USER_ID and DEFAULT_USER_NAME overrides", () => {
     process.env.DEFAULT_USER_ID = "custom-user";
     process.env.DEFAULT_USER_NAME = "Custom Name";
 
@@ -45,10 +71,35 @@ describe("LocalUserContextProvider", () => {
     });
   });
 
+  it("falls back to defaults when env vars are unset", () => {
+    delete process.env.DEFAULT_USER_ID;
+    delete process.env.DEFAULT_USER_NAME;
+
+    expect(provider.getCurrentUser()).toEqual(DEFAULT_LOCAL_USER);
+  });
+
   it("falls back to defaults when env vars are blank", () => {
     process.env.DEFAULT_USER_ID = "   ";
     process.env.DEFAULT_USER_NAME = "";
 
     expect(provider.getCurrentUser()).toEqual(DEFAULT_LOCAL_USER);
+  });
+
+  it("returns authType LOCAL_FAKE", () => {
+    const user = provider.getCurrentUser();
+    expect(user.authType).toBe("LOCAL_FAKE");
+  });
+
+  it("returns expected User shape", () => {
+    const user = provider.getCurrentUser();
+    const keys = Object.keys(user).sort();
+
+    expect(keys).toEqual(["authType", "displayName", "userId"]);
+    expect(typeof user.userId).toBe("string");
+    expect(typeof user.displayName).toBe("string");
+    expect(typeof user.authType).toBe("string");
+
+    const typedUser: User = user;
+    expect(typedUser).toBeDefined();
   });
 });

--- a/agent/lib/user/LocalUserContextProvider.ts
+++ b/agent/lib/user/LocalUserContextProvider.ts
@@ -1,0 +1,28 @@
+import type { UserContextProvider } from "@/lib/user/UserContextProvider";
+import type { User } from "@/lib/user/types";
+
+export const DEFAULT_LOCAL_USER: User = {
+  userId: "local",
+  displayName: "Local User",
+  authType: "LOCAL_FAKE",
+};
+
+function readEnvOrDefault(name: "DEFAULT_USER_ID" | "DEFAULT_USER_NAME", fallback: string): string {
+  const value = process.env[name];
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+export class LocalUserContextProvider implements UserContextProvider {
+  getCurrentUser(): User {
+    return {
+      userId: readEnvOrDefault("DEFAULT_USER_ID", DEFAULT_LOCAL_USER.userId),
+      displayName: readEnvOrDefault("DEFAULT_USER_NAME", DEFAULT_LOCAL_USER.displayName),
+      authType: DEFAULT_LOCAL_USER.authType,
+    };
+  }
+}

--- a/agent/lib/user/UserContextProvider.ts
+++ b/agent/lib/user/UserContextProvider.ts
@@ -1,0 +1,5 @@
+import type { User } from "@/lib/user/types";
+
+export interface UserContextProvider {
+  getCurrentUser(): User;
+}

--- a/agent/lib/user/index.ts
+++ b/agent/lib/user/index.ts
@@ -1,0 +1,3 @@
+export type { User } from "@/lib/user/types";
+export type { UserContextProvider } from "@/lib/user/UserContextProvider";
+export { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";

--- a/agent/lib/user/types.ts
+++ b/agent/lib/user/types.ts
@@ -1,0 +1,7 @@
+export type AuthType = "LOCAL_FAKE" | "SSO" | "OAUTH" | "DB";
+
+export interface User {
+  userId: string;
+  displayName: string;
+  authType: AuthType;
+}


### PR DESCRIPTION
## Summary\n- introduce a user context abstraction with User, UserContextProvider, and LocalUserContextProvider\n- centralize DEFAULT_USER_ID/DEFAULT_USER_NAME env access in the local provider\n- add/export gent/lib/user/index.ts\n- expand provider tests to 8 acceptance-focused cases\n\n## Validation\n- cd agent && npm test\n