### PR TITLE
docs(architecture): APE-35 align user context governance docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,7 @@
 
 - **UI / Client:** Collects chat + structured `portfolio_state`, renders chat as supportive UX, and treats Decision Snapshot as authoritative output.
 - **API / Service layer:** `POST /api/chat` validates request shape, orchestrates decision flow, applies guardrails, and emits snapshot.
+- **User context (platform):** User identity is resolved only via `UserContextProvider`; domain/business logic must be user-scoped and must not read env/auth inputs directly.
 - **Data store(s):** File-based policy/config artifacts (`artifacts/policy/default/*`, optional `artifacts/local/*`) are source of truth; no DB through Milestone 3c.
 At runtime, policy must be provided via explicit configuration; repo artifacts are not valid runtime dependencies.
 Policy follows a two-layer model: an immutable, release-scoped governance bundle (policy JSON + Prime Directive markdown) is baked into the build/image and loaded in production via `POLICY_DIR` (for example, `/app/policy`), while a versioned, data-scoped user policy instance is derived from questionnaire outputs and used to set SAA (rare updates) with regular TAA overlays constrained by governance guardrails.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ---
 
+## 2026-02-11 — Iteration M4 (User Context Abstraction Seam)
+### Added
+- Introduced `UserContextProvider` seam with `LocalUserContextProvider` (env-backed defaults via `DEFAULT_USER_ID` and `DEFAULT_USER_NAME`) to keep identity resolution platform-scoped.
+
+---
+
 ## 2026-01-27 — Iteration M1 (Policy Enforcement Baseline)
 ### Added
 - Policy loader with default/local artifact resolution and governance hash freeze checks.

--- a/docs/decisions/ADR-0006-introduce-user-context-abstraction.md
+++ b/docs/decisions/ADR-0006-introduce-user-context-abstraction.md
@@ -1,0 +1,39 @@
+# Title
+ADR-0006: Introduce User Context Abstraction (Interface-first, Local Implementation)
+
+# Status
+Accepted
+
+# Date
+2026-02-11
+
+# Context
+Current MVP behavior is effectively single-user, but user identity concerns were at risk of spreading across services via direct env reads and hard-coded IDs.
+We need a seam that keeps runtime behavior unchanged while enabling future user-scoped lifecycle/persistence work.
+
+# Decision
+Introduce a platform-level `UserContextProvider` abstraction:
+- `User`: `userId`, `displayName`, `authType`
+- `UserContextProvider#getCurrentUser(): User` (synchronous for MVP)
+- `LocalUserContextProvider` as MVP implementation, reading `DEFAULT_USER_ID` and `DEFAULT_USER_NAME` with defaults `"local"` and `"Local User"`, and `authType: "LOCAL_FAKE"`
+
+# Invariants
+- All user resolution must go through `UserContextProvider`.
+- Direct access to `process.env.DEFAULT_USER_ID` or `process.env.DEFAULT_USER_NAME` is prohibited outside `LocalUserContextProvider`.
+- New code paths must not hard-code `"local"` outside `LocalUserContextProvider` defaults.
+- Business/domain logic must accept `userId` as an input dependency; it must not resolve identity internally.
+- `authType` is descriptive metadata in MVP and must not drive authorization decisions.
+
+# Consequences
+- Positive: identity resolution is centralized, deterministic for MVP, and replaceable later without refactoring domain boundaries.
+- Positive: future multi-user policy lifecycle/persistence can be introduced behind the same seam.
+- Negative: code touching user-scoped behavior must explicitly thread `userId`.
+
+# Alternatives considered
+- Continue direct env reads in services (rejected: leaks platform concerns into domain logic).
+- Hard-code a global local user everywhere (rejected: blocks clean multi-user evolution).
+- Add full auth now (rejected: out of scope for MVP milestones).
+
+# Notes / Links
+- Related architecture update: `docs/ARCHITECTURE.md`
+- Related changelog entry: `docs/CHANGELOG.md`

--- a/docs/reference/APE-35-user-context-abstraction-story.md
+++ b/docs/reference/APE-35-user-context-abstraction-story.md
@@ -1,0 +1,28 @@
+# User story: User context abstraction for user-scoped policy lifecycle
+
+## Background / Why
+APE needs a platform seam for user identity so policy lifecycle and persistence can become user-scoped without leaking env/auth concerns into domain logic.
+MVP remains deterministic and local-user based, but implementation boundaries must be future-ready.
+
+## Acceptance criteria
+- User identity is resolved only via `UserContextProvider`.
+- `LocalUserContextProvider` is the only location allowed to read `DEFAULT_USER_ID` and `DEFAULT_USER_NAME`.
+- New code paths do not hard-code `"local"` outside provider defaults.
+- Business/domain logic accepts `userId` as an injected/input dependency and does not resolve identity internally.
+- `authType` is descriptive only in MVP and is not used for authorization decisions.
+
+## Test expectations
+- Unit tests verify provider default output shape (`userId`, `displayName`, `authType`) and deterministic values.
+- Unit tests verify env overrides for `DEFAULT_USER_ID` and `DEFAULT_USER_NAME`.
+- Guardrail test expectation: no direct env reads for default user identity outside `LocalUserContextProvider`.
+- Service-level test expectation: user-scoped flows pass/use a consistent `userId` dependency.
+
+## Out of scope
+- Real authentication or session management flows.
+- Full multi-user persistence implementation.
+- Routing/UI/dashboard changes.
+
+## Links
+- ADR: `docs/decisions/ADR-0006-introduce-user-context-abstraction.md`
+- Architecture: `docs/ARCHITECTURE.md`
+- Changelog: `docs/CHANGELOG.md`


### PR DESCRIPTION
## Summary
- add ADR-0006 for User Context Abstraction (interface-first, local implementation)
- add minimal architecture note making UserContextProvider the identity seam
- add changelog bullet for M4 user-context platform seam
- add APE-35 backlog story stub with acceptance criteria and test expectations
- keep scope docs-only with no production code changes
