### PR TITLE
docs(architecture): APE-36 align policy state repository governance docs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,6 +22,7 @@
 - **UI / Client:** Collects chat + structured `portfolio_state`, renders chat as supportive UX, and treats Decision Snapshot as authoritative output.
 - **API / Service layer:** `POST /api/chat` validates request shape, orchestrates decision flow, applies guardrails, and emits snapshot.
 - **User context (platform):** User identity is resolved only via `UserContextProvider`; domain/business logic must be user-scoped and must not read env/auth inputs directly.
+- **Policy state repository (platform/data):** User-scoped policy lifecycle artifacts are persisted behind `PolicyStateRepository` (MVP `JsonPolicyStateRepository`) with storage root configured by `POLICY_STATE_DIR`.
 - **Data store(s):** File-based policy/config artifacts (`artifacts/policy/default/*`, optional `artifacts/local/*`) are source of truth; no DB through Milestone 3c.
 At runtime, policy must be provided via explicit configuration; repo artifacts are not valid runtime dependencies.
 Policy follows a two-layer model: an immutable, release-scoped governance bundle (policy JSON + Prime Directive markdown) is baked into the build/image and loaded in production via `POLICY_DIR` (for example, `/app/policy`), while a versioned, data-scoped user policy instance is derived from questionnaire outputs and used to set SAA (rare updates) with regular TAA overlays constrained by governance guardrails.
@@ -32,7 +33,7 @@ Policy follows a two-layer model: an immutable, release-scoped governance bundle
 - Core entities: `ChatRequest`, `PortfolioStateInput`, `PolicyJson`, `DecisionSnapshot`.
 - Key identifiers: `snapshot_id`, `policy_id`, `policy_version`.
 - Ownership / source of truth: deterministic evaluation fields owned by service logic + policy artifacts; recommendation/explanation text proposed by model then constrained by guardrails.
-- Retention / archival assumptions: snapshots are returned per request only; long-term persistence not implemented.
+- Retention / archival assumptions: snapshots are returned per request only; policy lifecycle state persists as user-scoped repository records.
 
 ## Core Flows
 ### Flow A — Governed decision with structured state
@@ -55,6 +56,7 @@ Policy follows a two-layer model: an immutable, release-scoped governance bundle
 - Deterministic policy/drift constraints have precedence over model creativity.
 - `recommendation.type` must remain within the closed enum.
 - Unsafe/invalid model outputs must degrade to safe recommendation types, not silent success.
+- Filesystem access for policy lifecycle persistence is confined to `JsonPolicyStateRepository` implementation boundaries.
 
 ## Observability (minimum)
 - Logs: server logs for policy provenance, fallback reasons, guardrail/explanation warnings; client debug logging gated by log level.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,14 @@
 
 ---
 
+## 2026-02-11 — Iteration M4a (Policy State Repository Seam)
+### Added
+- Added `PolicyStateRepository` seam with `JsonPolicyStateRepository` MVP for user-scoped policy lifecycle artifacts.
+- Added `POLICY_STATE_DIR` runtime configuration for policy state storage root.
+- Missing lifecycle artifacts are represented explicitly as `null` (no silent defaults).
+
+---
+
 ## 2026-01-27 — Iteration M1 (Policy Enforcement Baseline)
 ### Added
 - Policy loader with default/local artifact resolution and governance hash freeze checks.

--- a/docs/decisions/ADR-0007-introduce-policy-state-repository-json-backed.md
+++ b/docs/decisions/ADR-0007-introduce-policy-state-repository-json-backed.md
@@ -1,0 +1,45 @@
+# Title
+ADR-0007: Introduce Policy State Repository (JSON-backed, Interface-first)
+
+# Status
+Accepted
+
+# Date
+2026-02-11
+
+# Context
+Policy lifecycle artifacts (IPS instance, risk profile, and portfolio guidelines instance) need persisted state that is user-scoped.
+The boundary must be interface-first so JSON storage can be replaced later (for example, with PostgreSQL) without pushing filesystem concerns into domain logic.
+
+# Decision
+Introduce `PolicyStateRepository` as the persistence seam with methods for read and targeted upsert by `userId`:
+- `getPolicyState(userId)`
+- `upsertIps(userId, ips)`
+- `upsertRiskProfile(userId, risk)`
+- `upsertGuidelines(userId, guidelines)`
+
+Adopt `JsonPolicyStateRepository` as the MVP implementation:
+- one JSON file per user
+- storage root configured via `POLICY_STATE_DIR`
+- atomic writes via temp file + rename
+- safe filename validation for `userId`
+- deterministic JSON formatting
+
+# Invariants
+- All policy lifecycle persistence is keyed by `userId`.
+- Filesystem access for policy lifecycle state is prohibited outside `JsonPolicyStateRepository`.
+- Missing lifecycle data is explicit (`null`) and must not be inferred through silent defaults.
+- Storage root is resolved from `POLICY_STATE_DIR` (with repository-defined default behavior).
+
+# Consequences
+- Positive: domain/service layers depend on a stable repository interface instead of filesystem details.
+- Positive: user-scoped lifecycle records are deterministic and reviewable in MVP.
+- Negative: JSON/file operational concerns remain in MVP until a backing store replacement is introduced.
+
+# Options considered
+- Direct filesystem reads/writes in services (rejected: leaks persistence mechanics beyond repository boundary).
+- Introduce database persistence immediately (deferred: unnecessary complexity for current milestone scope).
+- Keep lifecycle state in-memory only (rejected: does not satisfy persistence requirement).
+
+# Follow-on work
+- Add a DB-backed implementation behind the same `PolicyStateRepository` interface when multi-user scale and operational requirements justify it.


### PR DESCRIPTION
## Summary
- add ADR-0007 for Policy State Repository (JSON-backed, interface-first)
- add minimal architecture boundary note for PolicyStateRepository and POLICY_STATE_DIR
- record invariant that policy lifecycle fs access is confined to JsonPolicyStateRepository
- add changelog entry for implemented APE-33 persistence seam and explicit-null behavior
- keep scope docs/governance-only with no production code changes
