### PR TITLE
ci: APE-37 fix commit-prefix workflow YAML parsing and PR triggers

### DIFF
--- a/.github/workflows/commit-prefix.yml
+++ b/.github/workflows/commit-prefix.yml
@@ -16,23 +16,22 @@ jobs:
 
           echo "Validating branch: $branch"
           echo "$branch" | grep -Eq "$regex" || {
-cat <<'EOF'
-Branch name is invalid.
-
-Required format:
-  <type>/APE<id>-<description>
-  <type>/APE-<id>-<description>
-
-Rules:
-  - <type> must be one of: feat, fix, chore, docs, refactor, test, ci, build, perf, style, hotfix
-  - <id> must be 1 to 3 digits
-  - <description> must be lowercase kebab-case
-
-Examples:
-  feat/APE1-plane-sync
-  chore/APE-11-update-workflow
-  docs/APE-111-add-setup-guide
-EOF
+            printf '%s\n' \
+              "Branch name is invalid." \
+              "" \
+              "Required format:" \
+              "  <type>/APE<id>-<description>" \
+              "  <type>/APE-<id>-<description>" \
+              "" \
+              "Rules:" \
+              "  - <type> must be one of: feat, fix, chore, docs, refactor, test, ci, build, perf, style, hotfix" \
+              "  - <id> must be 1 to 3 digits" \
+              "  - <description> must be lowercase kebab-case" \
+              "" \
+              "Examples:" \
+              "  feat/APE1-plane-sync" \
+              "  chore/APE-11-update-workflow" \
+              "  docs/APE-111-add-setup-guide"
             exit 1
           }
 

--- a/.github/workflows/commit-prefix.yml
+++ b/.github/workflows/commit-prefix.yml
@@ -2,6 +2,7 @@ name: Commit Prefix Check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   branch-name:
@@ -16,22 +17,22 @@ jobs:
           echo "Validating branch: $branch"
           echo "$branch" | grep -Eq "$regex" || {
             cat <<'EOF'
-Branch name is invalid.
+            Branch name is invalid.
 
-Required format:
-  <type>/APE<id>-<description>
-  <type>/APE-<id>-<description>
+            Required format:
+              <type>/APE<id>-<description>
+              <type>/APE-<id>-<description>
 
-Rules:
-  - <type> must be one of: feat, fix, chore, docs, refactor, test, ci, build, perf, style, hotfix
-  - <id> must be 1 to 3 digits
-  - <description> must be lowercase kebab-case
+            Rules:
+              - <type> must be one of: feat, fix, chore, docs, refactor, test, ci, build, perf, style, hotfix
+              - <id> must be 1 to 3 digits
+              - <description> must be lowercase kebab-case
 
-Examples:
-  feat/APE1-plane-sync
-  chore/APE-11-update-workflow
-  docs/APE-111-add-setup-guide
-EOF
+            Examples:
+              feat/APE1-plane-sync
+              chore/APE-11-update-workflow
+              docs/APE-111-add-setup-guide
+            EOF
             exit 1
           }
 

--- a/.github/workflows/commit-prefix.yml
+++ b/.github/workflows/commit-prefix.yml
@@ -16,23 +16,23 @@ jobs:
 
           echo "Validating branch: $branch"
           echo "$branch" | grep -Eq "$regex" || {
-            cat <<'EOF'
-            Branch name is invalid.
+cat <<'EOF'
+Branch name is invalid.
 
-            Required format:
-              <type>/APE<id>-<description>
-              <type>/APE-<id>-<description>
+Required format:
+  <type>/APE<id>-<description>
+  <type>/APE-<id>-<description>
 
-            Rules:
-              - <type> must be one of: feat, fix, chore, docs, refactor, test, ci, build, perf, style, hotfix
-              - <id> must be 1 to 3 digits
-              - <description> must be lowercase kebab-case
+Rules:
+  - <type> must be one of: feat, fix, chore, docs, refactor, test, ci, build, perf, style, hotfix
+  - <id> must be 1 to 3 digits
+  - <description> must be lowercase kebab-case
 
-            Examples:
-              feat/APE1-plane-sync
-              chore/APE-11-update-workflow
-              docs/APE-111-add-setup-guide
-            EOF
+Examples:
+  feat/APE1-plane-sync
+  chore/APE-11-update-workflow
+  docs/APE-111-add-setup-guide
+EOF
             exit 1
           }
 


### PR DESCRIPTION
## Summary
- fix invalid YAML in .github/workflows/commit-prefix.yml by indenting heredoc content under un: |
- keep workflow/job names unchanged (Commit Prefix Check, ranch-name, commit-prefix)
- add explicit PR trigger types: opened, synchronize, eopened
- preserve fail-fast behavior (non-zero exit on invalid branch/commit format)

## Verification
- open PR and confirm Commit Prefix Check runs
- confirm jobs ranch-name and commit-prefix appear and complete
