### PR TITLE
docs: APE-41 immortalize non-negotiable IPS->Risk->Guidelines lifecycle

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,8 +39,68 @@
 - Ownership / source of truth: deterministic evaluation fields owned by service logic + runtime governance bundle (from `POLICY_DIR`, authored in artifacts); recommendation/explanation text proposed by model then constrained by guardrails.
 - Retention / archival assumptions: snapshots are returned per request only; policy lifecycle state persists as user-scoped repository records.
 
+### Policy Object Taxonomy
+- **Investment Policy Statement (IPS):** governance-level policy defining objectives, constraints, authority model, and prohibited actions; versioned and changed deliberately.
+- **Portfolio Guidelines:** operational rules derived from the IPS (asset allocation targets, rebalancing bands, turnover/execution controls, risk guardrails); versioned and adjusted through review/risk updates.
+- **Risk Profile:** questionnaire-derived classification that selects or parameterizes Portfolio Guidelines; it does not mutate the IPS.
+- **Executable Portfolio Guidelines (Runtime Policy):** deterministic machine-readable policy package loaded via `POLICY_PATH`/`POLICY_DIR` for runtime decision execution.
+
 ## Core Flows
 Lifecycle ordering is explicit: IPS -> Risk Profile -> Portfolio Guidelines -> Executable Policy. Portfolio Guidelines must not be created during IPS setup.
+### Canonical Policy Lifecycle Rule (APE)
+
+> **In APE, the Investment Policy Statement (IPS) is established first and independently.
+> Portfolio Guidelines are never created, selected, or modified during IPS setup.
+> Portfolio Guidelines are derived only after a Risk Profile exists, and always within the constraints of the IPS.**
+
+#### Authoritative sequencing (non-negotiable)
+
+This sequence is **fixed** and must not be reordered:
+
+1. **IPS Setup (Wizard)**
+   * Purpose: establish governance, intent, and constraints
+   * Output: **IPS Instance** (versioned, hashed, immutable)
+   * Explicitly excludes:
+     * asset allocation
+     * rebalancing rules
+     * execution preferences
+
+2. **Risk Questionnaire**
+   * Purpose: assess risk tolerance and capacity
+   * Output: **Risk Profile** (versioned)
+
+3. **Portfolio Guidelines Derivation**
+   * Purpose: translate Risk Profile into operational rules
+   * Input: IPS Instance + Risk Profile
+   * Output: **Portfolio Guidelines Instance**
+
+4. **Compilation**
+   * Purpose: produce deterministic runtime configuration
+   * Output: **Executable Portfolio Guidelines** (runtime policy JSON)
+
+5. **Decision Execution**
+   * Decisions are permitted only if a valid Executable Portfolio Guidelines package exists
+
+#### Hard invariants (design constraints)
+
+These are **system laws**, not conventions:
+
+* An IPS **must exist** before a Risk Profile is interpreted
+* Portfolio Guidelines **must not exist** without a Risk Profile
+* Questionnaire results **must not mutate** the IPS
+* Changes in risk posture **do not imply** IPS changes
+* IPS changes require a **new IPS instance** (versioned), never in-place mutation
+
+#### Adviser-aligned rationale (for future justification)
+
+This mirrors orthodox advisory practice:
+
+* IPS defines *permission and process*
+* Risk assessment defines *posture*
+* Portfolio construction implements *within policy*
+* Policy changes only on review or life event
+
+NOTE: Do not duplicate this content in other docs. ARCHITECTURE is authoritative.
 
 ### Flow A — Governed decision with structured state
 1. UI sends chat history plus optional structured `portfolio_state` to `POST /api/chat`.
@@ -86,4 +146,5 @@ Lifecycle ordering is explicit: IPS -> Risk Profile -> Portfolio Guidelines -> E
 ## Links
 - Decision log: `docs/decisions/`
 - Change log: `docs/CHANGELOG.md`
+
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,8 @@
 ### Changed
 - Docs consolidation: removed non-authoritative duplicates; clarified authoritative doc set and policy loading boundary.
 - Terminology: rename IPM -> Portfolio Guidelines (CFA-aligned); no behavior changes.
+- Docs: added canonical policy lifecycle rule and invariants (IPS -> Risk Profile -> Portfolio Guidelines -> Executable Guidelines).
+- Docs: standardized policy object taxonomy across architecture/ADRs (IPS, Portfolio Guidelines, Risk Profile, Executable Portfolio Guidelines).
 
 ---
 
@@ -189,3 +191,4 @@
 ---
 ## Milestone 3c Marker
 Backfilled documentation is complete through Milestone 3c.
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Terminology: rename IPM -> Portfolio Guidelines (CFA-aligned); no behavior changes.
 - Docs: added canonical policy lifecycle rule and invariants (IPS -> Risk Profile -> Portfolio Guidelines -> Executable Guidelines).
 - Docs: standardized policy object taxonomy across architecture/ADRs (IPS, Portfolio Guidelines, Risk Profile, Executable Portfolio Guidelines).
+- Docs: codified non-negotiable policy lifecycle invariant (IPS precedes Risk Profile; Guidelines derived only after Risk Profile).
 
 ---
 

--- a/docs/decisions/ADR-0005-adopt-baked-governance-policy-bundle-for-production.md
+++ b/docs/decisions/ADR-0005-adopt-baked-governance-policy-bundle-for-production.md
@@ -16,6 +16,7 @@ Governance hash pinning is enforced through `meta.prime_directive_sha256`, so ru
 Adopt Option A for production: ship a release-scoped immutable governance policy bundle (policy JSON + Prime Directive markdown) baked into the build/image, and configure `POLICY_DIR` to that baked path (for example, `/app/policy`).
 `ALLOW_ARTIFACTS_READ` is prohibited outside development contexts.
 Runtime must fail fast on missing policy source or hash mismatch; there is no silent fallback to unpinned policies.
+Terminology alignment: this runtime package is the Executable Portfolio Guidelines bundle consumed by the decision engine.
 
 # Consequences
 - Build/release pipelines must include the policy bundle and Prime Directive in the image and record bundle hashes plus image digest at build/release time.

--- a/docs/decisions/ADR-0007-introduce-policy-state-repository-json-backed.md
+++ b/docs/decisions/ADR-0007-introduce-policy-state-repository-json-backed.md
@@ -12,6 +12,8 @@ Policy lifecycle artifacts (IPS instance, risk profile, and portfolio guidelines
 The boundary must be interface-first so JSON storage can be replaced later (for example, with PostgreSQL) without pushing filesystem concerns into domain logic.
 Terminology alignment: IPS is the governance document, Portfolio Guidelines are operational rules derived from IPS, and Risk Profile is questionnaire output used to derive/select guidelines.
 
+Invariant: “In APE, the Investment Policy Statement (IPS) is established first and independently. Portfolio Guidelines are never created, selected, or modified during IPS setup. Portfolio Guidelines are derived only after a Risk Profile exists, and always within the constraints of the IPS.”
+
 # Decision
 Introduce `PolicyStateRepository` as the persistence seam with methods for read and targeted upsert by `userId`:
 - `getPolicyState(userId)`

--- a/docs/decisions/ADR-0007-introduce-policy-state-repository-json-backed.md
+++ b/docs/decisions/ADR-0007-introduce-policy-state-repository-json-backed.md
@@ -10,6 +10,7 @@ Accepted
 # Context
 Policy lifecycle artifacts (IPS instance, risk profile, and portfolio guidelines instance) need persisted state that is user-scoped.
 The boundary must be interface-first so JSON storage can be replaced later (for example, with PostgreSQL) without pushing filesystem concerns into domain logic.
+Terminology alignment: IPS is the governance document, Portfolio Guidelines are operational rules derived from IPS, and Risk Profile is questionnaire output used to derive/select guidelines.
 
 # Decision
 Introduce `PolicyStateRepository` as the persistence seam with methods for read and targeted upsert by `userId`:


### PR DESCRIPTION
## Summary\n- codifies the non-negotiable policy lifecycle invariant in architecture docs\n- keeps canonical ordering explicit: IPS setup -> Risk Profile -> Portfolio Guidelines derivation -> Compilation -> Decision execution\n- adds invariant statement to existing lifecycle-related ADR (no new ADR)\n- adds changelog entry for lifecycle invariant codification\n\n## Files changed\n- docs/ARCHITECTURE.md\n- docs/decisions/ADR-0007-introduce-policy-state-repository-json-backed.md\n- docs/CHANGELOG.md\n\n## Validation\n- cd agent && npm test (pass)\n\nNo behavior change; docs-only invariant.