### PR TITLE
APE-34: Implement Policy Lifecycle Resolver

### DIFF
--- a/agent/lib/policy/LifecycleResolver.test.ts
+++ b/agent/lib/policy/LifecycleResolver.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveLifecycleState } from "@/lib/policy/LifecycleResolver";
+import type { PolicyState } from "@/lib/policy/types";
+
+describe("resolveLifecycleState", () => {
+  it('returns "NO_IPS" for null policy state', () => {
+    expect(resolveLifecycleState(null)).toBe("NO_IPS");
+  });
+
+  it('returns "IPS_DRAFT" for IPS draft status', () => {
+    const state: PolicyState = {
+      userId: "user1",
+      ips: {
+        ipsVersion: "v1",
+        ipsSha256: "abc123",
+        status: "DRAFT",
+        createdAtIso: "2026-02-12T00:00:00.000Z",
+        content: "ips",
+      },
+    };
+
+    expect(resolveLifecycleState(state)).toBe("IPS_DRAFT");
+  });
+
+  it('returns "RISK_PROFILE_MISSING" for frozen IPS with no risk profile', () => {
+    const state: PolicyState = {
+      userId: "user1",
+      ips: {
+        ipsVersion: "v1",
+        ipsSha256: "abc123",
+        status: "FROZEN",
+        createdAtIso: "2026-02-12T00:00:00.000Z",
+        content: "ips",
+      },
+    };
+
+    expect(resolveLifecycleState(state)).toBe("RISK_PROFILE_MISSING");
+  });
+
+  it('returns "RISK_PROFILE_FROZEN" for frozen risk profile with no guidelines', () => {
+    const state: PolicyState = {
+      userId: "user1",
+      riskProfile: {
+        version: "v1",
+        status: "FROZEN",
+        createdAtIso: "2026-02-12T00:05:00.000Z",
+        summary: "summary",
+      },
+    };
+
+    expect(resolveLifecycleState(state)).toBe("RISK_PROFILE_FROZEN");
+  });
+
+  it('returns "GUIDELINES_DERIVED" for derived guidelines status', () => {
+    const state: PolicyState = {
+      userId: "user1",
+      guidelines: {
+        version: "v1",
+        status: "DERIVED",
+        createdAtIso: "2026-02-12T00:10:00.000Z",
+        payloadJson: "{}",
+      },
+    };
+
+    expect(resolveLifecycleState(state)).toBe("GUIDELINES_DERIVED");
+  });
+
+  it('returns "GUIDELINES_COMPILED" for compiled guidelines status', () => {
+    const state: PolicyState = {
+      userId: "user1",
+      guidelines: {
+        version: "v1",
+        status: "COMPILED",
+        createdAtIso: "2026-02-12T00:10:00.000Z",
+        payloadJson: "{}",
+      },
+    };
+
+    expect(resolveLifecycleState(state)).toBe("GUIDELINES_COMPILED");
+  });
+});

--- a/agent/lib/policy/LifecycleResolver.ts
+++ b/agent/lib/policy/LifecycleResolver.ts
@@ -1,0 +1,43 @@
+import type { PolicyState } from "@/lib/policy/types";
+
+export type PolicyLifecycleState =
+  | "NO_IPS"
+  | "IPS_DRAFT"
+  | "RISK_PROFILE_MISSING"
+  | "RISK_PROFILE_FROZEN"
+  | "GUIDELINES_DERIVED"
+  | "GUIDELINES_COMPILED";
+
+export function resolveLifecycleState(policyState: PolicyState | null): PolicyLifecycleState {
+  if (policyState === null) {
+    return "NO_IPS";
+  }
+
+  if (policyState.ips?.status === "DRAFT") {
+    return "IPS_DRAFT";
+  }
+
+  if (
+    policyState.ips?.status === "FROZEN" &&
+    (!policyState.riskProfile || policyState.riskProfile.status === "MISSING")
+  ) {
+    return "RISK_PROFILE_MISSING";
+  }
+
+  if (
+    policyState.riskProfile?.status === "FROZEN" &&
+    (!policyState.guidelines || policyState.guidelines.status === "MISSING")
+  ) {
+    return "RISK_PROFILE_FROZEN";
+  }
+
+  if (policyState.guidelines?.status === "DERIVED") {
+    return "GUIDELINES_DERIVED";
+  }
+
+  if (policyState.guidelines?.status === "COMPILED") {
+    return "GUIDELINES_COMPILED";
+  }
+
+  return "NO_IPS";
+}


### PR DESCRIPTION
## Summary
- add pure deterministic esolveLifecycleState(policyState: PolicyState | null) in gent/lib/policy/LifecycleResolver.ts
- define closed PolicyLifecycleState union with only: NO_IPS, IPS_DRAFT, RISK_PROFILE_MISSING, RISK_PROFILE_FROZEN, GUIDELINES_DERIVED, GUIDELINES_COMPILED
- add unit tests in gent/lib/policy/LifecycleResolver.test.ts for all required lifecycle outcomes

## Behavior
Resolver rules are evaluated in strict order:
1. 
ull => NO_IPS
2. IPS DRAFT => IPS_DRAFT
3. IPS FROZEN + missing/MISSING risk profile => RISK_PROFILE_MISSING
4. Risk profile FROZEN + missing/MISSING guidelines => RISK_PROFILE_FROZEN
5. Guidelines DERIVED => GUIDELINES_DERIVED
6. Guidelines COMPILED => GUIDELINES_COMPILED

For unmatched structural combinations, resolver falls back deterministically to NO_IPS without introducing extra states.

## Validation
- cd agent && npm test
- Result: 12 test files passed, 80 tests passed

## Constraints satisfied
- pure function
- no repository calls
- no fs/env/I-O in resolver
- no additional lifecycle states