### PR TITLE
APE-44: Add dashboard lifecycle steps widget with single CTA

### DIFF
--- a/agent/app/dashboard/page.tsx
+++ b/agent/app/dashboard/page.tsx
@@ -1,0 +1,19 @@
+import DashboardStatus from "@/components/DashboardStatus";
+import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
+import { resolveLifecycleState } from "@/lib/policy/LifecycleResolver";
+import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
+
+export default async function DashboardPage() {
+  const userProvider = new LocalUserContextProvider();
+  const user = userProvider.getCurrentUser();
+
+  const policyRepository = new JsonPolicyStateRepository();
+  const policyState = await policyRepository.getPolicyState(user.userId);
+  const lifecycleState = resolveLifecycleState(policyState);
+
+  return (
+    <main className="app">
+      <DashboardStatus lifecycleState={lifecycleState} />
+    </main>
+  );
+}

--- a/agent/components/DashboardStatus.test.tsx
+++ b/agent/components/DashboardStatus.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import DashboardStatus from "@/components/DashboardStatus";
+import { getDashboardModel, type StepStatus } from "@/components/dashboardStatusMapping";
+import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
+
+describe("dashboardStatusMapping", () => {
+  const cases: Array<{
+    lifecycle: PolicyLifecycleState;
+    expectedLabel: string;
+    expectedHref: string;
+    expectedSteps: {
+      IPS: StepStatus;
+      RISK: StepStatus;
+      GUIDELINES: StepStatus;
+      DECISIONS: StepStatus;
+    };
+  }> = [
+    {
+      lifecycle: "NO_IPS",
+      expectedLabel: "Set up IPS",
+      expectedHref: "/setup/ips",
+      expectedSteps: {
+        IPS: "NOT_STARTED",
+        RISK: "LOCKED",
+        GUIDELINES: "LOCKED",
+        DECISIONS: "LOCKED",
+      },
+    },
+    {
+      lifecycle: "IPS_DRAFT",
+      expectedLabel: "Complete IPS",
+      expectedHref: "/setup/ips",
+      expectedSteps: {
+        IPS: "IN_PROGRESS",
+        RISK: "LOCKED",
+        GUIDELINES: "LOCKED",
+        DECISIONS: "LOCKED",
+      },
+    },
+    {
+      lifecycle: "RISK_PROFILE_MISSING",
+      expectedLabel: "Complete Risk Profile",
+      expectedHref: "/setup/risk-profile",
+      expectedSteps: {
+        IPS: "COMPLETE",
+        RISK: "NOT_STARTED",
+        GUIDELINES: "LOCKED",
+        DECISIONS: "LOCKED",
+      },
+    },
+    {
+      lifecycle: "RISK_PROFILE_FROZEN",
+      expectedLabel: "Create Guidelines",
+      expectedHref: "/setup/guidelines",
+      expectedSteps: {
+        IPS: "COMPLETE",
+        RISK: "COMPLETE",
+        GUIDELINES: "NOT_STARTED",
+        DECISIONS: "LOCKED",
+      },
+    },
+    {
+      lifecycle: "GUIDELINES_DERIVED",
+      expectedLabel: "Review Guidelines",
+      expectedHref: "/setup/guidelines",
+      expectedSteps: {
+        IPS: "COMPLETE",
+        RISK: "COMPLETE",
+        GUIDELINES: "IN_PROGRESS",
+        DECISIONS: "LOCKED",
+      },
+    },
+    {
+      lifecycle: "GUIDELINES_COMPILED",
+      expectedLabel: "Go to Decisions",
+      expectedHref: "/decisions",
+      expectedSteps: {
+        IPS: "COMPLETE",
+        RISK: "COMPLETE",
+        GUIDELINES: "COMPLETE",
+        DECISIONS: "NOT_STARTED",
+      },
+    },
+  ];
+
+  it.each(cases)("returns deterministic model for $lifecycle", ({ lifecycle, expectedLabel, expectedHref, expectedSteps }) => {
+    const model = getDashboardModel(lifecycle);
+
+    expect(model.cta.label).toBe(expectedLabel);
+    expect(model.cta.href).toBe(expectedHref);
+    expect(model.steps).toEqual(expectedSteps);
+  });
+});
+
+describe("DashboardStatus", () => {
+  it("renders fixed 4 steps and exactly one CTA link", () => {
+    render(<DashboardStatus lifecycleState="RISK_PROFILE_MISSING" />);
+
+    expect(screen.getByText("IPS")).toBeInTheDocument();
+    expect(screen.getByText("Risk Profile")).toBeInTheDocument();
+    expect(screen.getByText("Portfolio Guidelines")).toBeInTheDocument();
+    expect(screen.getByText("Decisions")).toBeInTheDocument();
+
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveTextContent("Complete Risk Profile");
+    expect(links[0]).toHaveAttribute("href", "/setup/risk-profile");
+  });
+});

--- a/agent/components/DashboardStatus.tsx
+++ b/agent/components/DashboardStatus.tsx
@@ -1,0 +1,40 @@
+import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
+import { getDashboardModel, type StepKey } from "@/components/dashboardStatusMapping";
+
+const STEP_ROWS: Array<{ key: StepKey; label: string }> = [
+  { key: "IPS", label: "IPS" },
+  { key: "RISK", label: "Risk Profile" },
+  { key: "GUIDELINES", label: "Portfolio Guidelines" },
+  { key: "DECISIONS", label: "Decisions" },
+];
+
+type DashboardStatusProps = {
+  lifecycleState: PolicyLifecycleState;
+};
+
+export default function DashboardStatus({ lifecycleState }: DashboardStatusProps) {
+  const model = getDashboardModel(lifecycleState);
+
+  return (
+    <section className="card" style={{ padding: 16 }}>
+      <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <tbody>
+          {STEP_ROWS.map((step) => (
+            <tr key={step.key}>
+              <td style={{ padding: "8px 0" }}>{step.label}</td>
+              <td style={{ padding: "8px 0", textAlign: "right" }}>
+                <span className="msg__bubble">{model.steps[step.key]}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div style={{ marginTop: 12 }}>
+        <a className="btn btn--primary" href={model.cta.href}>
+          {model.cta.label}
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/agent/components/dashboardStatusMapping.ts
+++ b/agent/components/dashboardStatusMapping.ts
@@ -1,0 +1,94 @@
+import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
+
+export type StepKey = "IPS" | "RISK" | "GUIDELINES" | "DECISIONS";
+
+export type StepStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETE" | "LOCKED";
+
+export type DashboardCTA = {
+  label: string;
+  href: string;
+};
+
+export type DashboardStateModel = {
+  steps: Record<StepKey, StepStatus>;
+  cta: DashboardCTA;
+};
+
+const DASHBOARD_STATE_MODELS: Record<PolicyLifecycleState, DashboardStateModel> = {
+  NO_IPS: {
+    steps: {
+      IPS: "NOT_STARTED",
+      RISK: "LOCKED",
+      GUIDELINES: "LOCKED",
+      DECISIONS: "LOCKED",
+    },
+    cta: {
+      label: "Set up IPS",
+      href: "/setup/ips",
+    },
+  },
+  IPS_DRAFT: {
+    steps: {
+      IPS: "IN_PROGRESS",
+      RISK: "LOCKED",
+      GUIDELINES: "LOCKED",
+      DECISIONS: "LOCKED",
+    },
+    cta: {
+      label: "Complete IPS",
+      href: "/setup/ips",
+    },
+  },
+  RISK_PROFILE_MISSING: {
+    steps: {
+      IPS: "COMPLETE",
+      RISK: "NOT_STARTED",
+      GUIDELINES: "LOCKED",
+      DECISIONS: "LOCKED",
+    },
+    cta: {
+      label: "Complete Risk Profile",
+      href: "/setup/risk-profile",
+    },
+  },
+  RISK_PROFILE_FROZEN: {
+    steps: {
+      IPS: "COMPLETE",
+      RISK: "COMPLETE",
+      GUIDELINES: "NOT_STARTED",
+      DECISIONS: "LOCKED",
+    },
+    cta: {
+      label: "Create Guidelines",
+      href: "/setup/guidelines",
+    },
+  },
+  GUIDELINES_DERIVED: {
+    steps: {
+      IPS: "COMPLETE",
+      RISK: "COMPLETE",
+      GUIDELINES: "IN_PROGRESS",
+      DECISIONS: "LOCKED",
+    },
+    cta: {
+      label: "Review Guidelines",
+      href: "/setup/guidelines",
+    },
+  },
+  GUIDELINES_COMPILED: {
+    steps: {
+      IPS: "COMPLETE",
+      RISK: "COMPLETE",
+      GUIDELINES: "COMPLETE",
+      DECISIONS: "NOT_STARTED",
+    },
+    cta: {
+      label: "Go to Decisions",
+      href: "/decisions",
+    },
+  },
+};
+
+export function getDashboardModel(lifecycle: PolicyLifecycleState): DashboardStateModel {
+  return DASHBOARD_STATE_MODELS[lifecycle];
+}


### PR DESCRIPTION
## Summary
- add /dashboard page that computes lifecycle state from user + policy state repository and renders a dashboard lifecycle widget
- add DashboardStatus component with fixed 4-step list and exactly one CTA rendered for every lifecycle state
- add single-source mapping module that drives both step statuses and CTA (getDashboardModel)
- add table-driven and render tests for mapping and widget behavior

## Files
- gent/app/dashboard/page.tsx
- gent/components/dashboardStatusMapping.ts
- gent/components/DashboardStatus.tsx
- gent/components/DashboardStatus.test.tsx

## Checklist review
- branch naming convention: pass (eat/APE-44-dashboard-status-widget)
- no lifecycle resolver logic changes (gent/lib/policy/LifecycleResolver.ts unchanged)
- no route guard/middleware introduced
- exactly one CTA per lifecycle state via mapping model

## Validation
- cd agent && npm test
- result: 13 test files passed, 87 tests passed