### PR TITLE
APE-43: Load dashboard lifecycle state for current user

### DIFF
--- a/agent/app/dashboard/page.tsx
+++ b/agent/app/dashboard/page.tsx
@@ -1,18 +1,12 @@
 import DashboardStatus from "@/components/DashboardStatus";
-import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
-import { resolveLifecycleState } from "@/lib/policy/LifecycleResolver";
-import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
+import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
 
 export default async function DashboardPage() {
-  const userProvider = new LocalUserContextProvider();
-  const user = userProvider.getCurrentUser();
-
-  const policyRepository = new JsonPolicyStateRepository();
-  const policyState = await policyRepository.getPolicyState(user.userId);
-  const lifecycleState = resolveLifecycleState(policyState);
+  const { lifecycleState } = await loadDashboardLifecycle();
 
   return (
     <main className="app">
+      <p>Lifecycle: {lifecycleState}</p>
       <DashboardStatus lifecycleState={lifecycleState} />
     </main>
   );

--- a/agent/lib/dashboard/loadDashboardLifecycle.test.ts
+++ b/agent/lib/dashboard/loadDashboardLifecycle.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
+import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
+import type { PolicyState } from "@/lib/policy/types";
+import type { UserContextProvider } from "@/lib/user/UserContextProvider";
+import type { User } from "@/lib/user/types";
+
+describe("loadDashboardLifecycle", () => {
+  it("uses current user id and resolves NO_IPS when policy state is missing", async () => {
+    const getCurrentUser = vi.fn<() => User>(() => ({
+      userId: "u123",
+      displayName: "User 123",
+      authType: "LOCAL_FAKE",
+    }));
+    const getPolicyState = vi.fn<(userId: string) => Promise<PolicyState | null>>(async () => null);
+
+    const userProvider: UserContextProvider = { getCurrentUser };
+    const policyRepo: PolicyStateRepository = {
+      getPolicyState,
+      upsertIps: vi.fn(async () => undefined),
+      upsertRiskProfile: vi.fn(async () => undefined),
+      upsertGuidelines: vi.fn(async () => undefined),
+    };
+
+    const result = await loadDashboardLifecycle({ userProvider, policyRepo });
+
+    expect(getCurrentUser).toHaveBeenCalledTimes(1);
+    expect(getPolicyState).toHaveBeenCalledTimes(1);
+    expect(getPolicyState).toHaveBeenCalledWith("u123");
+    expect(result).toEqual({
+      userId: "u123",
+      lifecycleState: "NO_IPS",
+    });
+  });
+
+  it("resolves IPS_DRAFT when IPS is draft", async () => {
+    const userProvider: UserContextProvider = {
+      getCurrentUser: vi.fn(() => ({
+        userId: "u123",
+        displayName: "User 123",
+        authType: "LOCAL_FAKE",
+      })),
+    };
+    const policyRepo: PolicyStateRepository = {
+      getPolicyState: vi.fn(async (userId: string) => ({
+        userId,
+        ips: {
+          ipsVersion: "v1",
+          ipsSha256: "abc123",
+          status: "DRAFT",
+          createdAtIso: "2026-02-12T00:00:00.000Z",
+          content: "ips",
+        },
+      })),
+      upsertIps: vi.fn(async () => undefined),
+      upsertRiskProfile: vi.fn(async () => undefined),
+      upsertGuidelines: vi.fn(async () => undefined),
+    };
+
+    const result = await loadDashboardLifecycle({ userProvider, policyRepo });
+
+    expect(policyRepo.getPolicyState).toHaveBeenCalledWith("u123");
+    expect(result.lifecycleState).toBe("IPS_DRAFT");
+  });
+});

--- a/agent/lib/dashboard/loadDashboardLifecycle.ts
+++ b/agent/lib/dashboard/loadDashboardLifecycle.ts
@@ -1,0 +1,28 @@
+import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
+import { resolveLifecycleState, type PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
+import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
+import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
+import type { UserContextProvider } from "@/lib/user/UserContextProvider";
+
+type LoadDashboardLifecycleDeps = {
+  userProvider?: UserContextProvider;
+  policyRepo?: PolicyStateRepository;
+};
+
+type DashboardLifecycleResult = {
+  userId: string;
+  lifecycleState: PolicyLifecycleState;
+};
+
+export async function loadDashboardLifecycle(
+  deps: LoadDashboardLifecycleDeps = {},
+): Promise<DashboardLifecycleResult> {
+  const userProvider = deps.userProvider ?? new LocalUserContextProvider();
+  const policyRepo = deps.policyRepo ?? new JsonPolicyStateRepository();
+
+  const { userId } = userProvider.getCurrentUser();
+  const policyState = await policyRepo.getPolicyState(userId);
+  const lifecycleState = resolveLifecycleState(policyState);
+
+  return { userId, lifecycleState };
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,13 @@
 
 ---
 
+## 2026-02-13 — Iteration M4c (Dashboard Lifecycle State)
+### Added
+- Server-side dashboard loader computes lifecycle state for current user using `UserContextProvider` + `PolicyStateRepository` + `resolveLifecycleState`.
+- `/dashboard` displays the computed lifecycle state value.
+
+---
+
 ## 2026-01-27 — Iteration M1 (Policy Enforcement Baseline)
 ### Added
 - Policy loader with default/local artifact resolution and governance hash freeze checks.


### PR DESCRIPTION
## Summary
- add loadDashboardLifecycle server-side loader to resolve lifecycle from current user policy state
- wire /dashboard to use the loader and render a minimal Lifecycle: <STATE> value
- add unit tests for dependency flow and deterministic lifecycle mapping; update changelog entry for APE-43

## Testing
- cd agent && npm test