### PR TITLE
docs(changelog): normalize APE-46 manual check formatting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,9 +17,9 @@
 - `/chat` route.
 
 ### Manual regression checks (quick)
-- [ ] Visiting `/` redirects to `/dashboard`.
-- [ ] Visiting `/chat` renders the chat UI.
-- [ ] `/dashboard` still renders as expected.
+- Visiting `/` redirects to `/dashboard`.
+- Visiting `/chat` renders the chat UI.
+- `/dashboard` still renders as expected.
 
 ---
 


### PR DESCRIPTION
## Summary
- normalize APE-46 changelog manual regression entries to plain bullets
- keep section structure consistent with existing changelog style

## Scope
- docs/CHANGELOG.md only
- no code changes