### PR TITLE
feat(app): APE-47 server-side route guards

### DIFF
--- a/agent/app/decisions/page.tsx
+++ b/agent/app/decisions/page.tsx
@@ -1,4 +1,15 @@
+import { redirect } from "next/navigation";
+
+import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
+import { canAccessDecisions } from "@/lib/guards/lifecycleGuards";
+
 export default async function DecisionsPage() {
+  const { lifecycleState } = await loadDashboardLifecycle();
+
+  if (!canAccessDecisions(lifecycleState)) {
+    redirect("/dashboard");
+  }
+
   return (
     <main>
       <h1>Decisions</h1>

--- a/agent/app/setup/guidelines/page.tsx
+++ b/agent/app/setup/guidelines/page.tsx
@@ -1,4 +1,15 @@
+import { redirect } from "next/navigation";
+
+import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
+import { canAccessGuidelines } from "@/lib/guards/lifecycleGuards";
+
 export default async function PortfolioGuidelinesPage() {
+  const { lifecycleState } = await loadDashboardLifecycle();
+
+  if (!canAccessGuidelines(lifecycleState)) {
+    redirect("/dashboard");
+  }
+
   return (
     <main>
       <h1>Portfolio Guidelines</h1>

--- a/agent/app/setup/risk-profile/page.tsx
+++ b/agent/app/setup/risk-profile/page.tsx
@@ -1,4 +1,15 @@
+import { redirect } from "next/navigation";
+
+import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
+import { canAccessRiskProfile } from "@/lib/guards/lifecycleGuards";
+
 export default async function RiskProfilePage() {
+  const { lifecycleState } = await loadDashboardLifecycle();
+
+  if (!canAccessRiskProfile(lifecycleState)) {
+    redirect("/dashboard");
+  }
+
   return (
     <main>
       <h1>Risk Profile</h1>

--- a/agent/lib/guards/lifecycleGuards.test.ts
+++ b/agent/lib/guards/lifecycleGuards.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canAccessDecisions,
+  canAccessGuidelines,
+  canAccessRiskProfile,
+} from "@/lib/guards/lifecycleGuards";
+
+describe("lifecycleGuards", () => {
+  it("enforces decisions access only for GUIDELINES_COMPILED", () => {
+    expect(canAccessDecisions("GUIDELINES_DERIVED")).toBe(false);
+    expect(canAccessDecisions("GUIDELINES_COMPILED")).toBe(true);
+  });
+
+  it("enforces risk profile access only after IPS is frozen", () => {
+    expect(canAccessRiskProfile("NO_IPS")).toBe(false);
+    expect(canAccessRiskProfile("RISK_PROFILE_MISSING")).toBe(true);
+  });
+
+  it("enforces guidelines access at or after RISK_PROFILE_FROZEN", () => {
+    expect(canAccessGuidelines("RISK_PROFILE_MISSING")).toBe(false);
+    expect(canAccessGuidelines("RISK_PROFILE_FROZEN")).toBe(true);
+  });
+});

--- a/agent/lib/guards/lifecycleGuards.ts
+++ b/agent/lib/guards/lifecycleGuards.ts
@@ -1,0 +1,19 @@
+import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
+
+const GUIDELINES_ACCESS_STATES: ReadonlySet<PolicyLifecycleState> = new Set([
+  "RISK_PROFILE_FROZEN",
+  "GUIDELINES_DERIVED",
+  "GUIDELINES_COMPILED",
+]);
+
+export function canAccessDecisions(state: PolicyLifecycleState): boolean {
+  return state === "GUIDELINES_COMPILED";
+}
+
+export function canAccessRiskProfile(state: PolicyLifecycleState): boolean {
+  return state !== "NO_IPS" && state !== "IPS_DRAFT";
+}
+
+export function canAccessGuidelines(state: PolicyLifecycleState): boolean {
+  return GUIDELINES_ACCESS_STATES.has(state);
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,7 @@
 
 ## Core Flows
 Lifecycle ordering is explicit: IPS -> Risk Profile -> Portfolio Guidelines -> Executable Policy. Portfolio Guidelines must not be created during IPS setup.
+Lifecycle order is enforced server-side via route guards using the same resolver path as the dashboard.
 ### Canonical Policy Lifecycle Rule (APE)
 
 > **In APE, the Investment Policy Statement (IPS) is established first and independently.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 - Visiting `/` now performs a server-side redirect to `/dashboard` (dashboard is the default landing route).
 - Chat UI remains reachable at `/chat` (moved from `/`).
+- Server-side route guards enforce lifecycle order for `/decisions`, `/setup/risk-profile`, and `/setup/guidelines` (redirect to `/dashboard` when disallowed).
 
 ### Added
 - `/chat` route.


### PR DESCRIPTION
- Adds server-side lifecycle route guards for `/decisions`, `/setup/risk-profile`, and `/setup/guidelines`.
- Reuses `loadDashboardLifecycle()` so guard computation matches dashboard (`UserContextProvider` -> `PolicyStateRepository` -> `resolveLifecycleState`).
- Applies consistent redirect behavior for disallowed access: `redirect("/dashboard")`.
- Introduces pure guard predicates in `agent/lib/guards/lifecycleGuards.ts` with focused unit tests.
- Updates docs: one architecture invariant sentence and changelog entry for the new route guard behavior.
