### PR TITLE
feat(app): APE-48 lifecycle next-action single source of truth

### DIFF
--- a/agent/app/decisions/page.tsx
+++ b/agent/app/decisions/page.tsx
@@ -1,13 +1,13 @@
 import { redirect } from "next/navigation";
 
 import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
-import { canAccessDecisions } from "@/lib/guards/lifecycleGuards";
+import { canAccessDecisions, getRedirectForLifecycle } from "@/lib/guards/lifecycleGuards";
 
 export default async function DecisionsPage() {
   const { lifecycleState } = await loadDashboardLifecycle();
 
   if (!canAccessDecisions(lifecycleState)) {
-    redirect("/dashboard");
+    redirect(getRedirectForLifecycle(lifecycleState));
   }
 
   return (

--- a/agent/app/setup/guidelines/page.tsx
+++ b/agent/app/setup/guidelines/page.tsx
@@ -1,13 +1,13 @@
 import { redirect } from "next/navigation";
 
 import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
-import { canAccessGuidelines } from "@/lib/guards/lifecycleGuards";
+import { canAccessGuidelines, getRedirectForLifecycle } from "@/lib/guards/lifecycleGuards";
 
 export default async function PortfolioGuidelinesPage() {
   const { lifecycleState } = await loadDashboardLifecycle();
 
   if (!canAccessGuidelines(lifecycleState)) {
-    redirect("/dashboard");
+    redirect(getRedirectForLifecycle(lifecycleState));
   }
 
   return (

--- a/agent/app/setup/risk-profile/page.tsx
+++ b/agent/app/setup/risk-profile/page.tsx
@@ -1,13 +1,13 @@
 import { redirect } from "next/navigation";
 
 import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
-import { canAccessRiskProfile } from "@/lib/guards/lifecycleGuards";
+import { canAccessRiskProfile, getRedirectForLifecycle } from "@/lib/guards/lifecycleGuards";
 
 export default async function RiskProfilePage() {
   const { lifecycleState } = await loadDashboardLifecycle();
 
   if (!canAccessRiskProfile(lifecycleState)) {
-    redirect("/dashboard");
+    redirect(getRedirectForLifecycle(lifecycleState));
   }
 
   return (

--- a/agent/components/DashboardStatus.test.tsx
+++ b/agent/components/DashboardStatus.test.tsx
@@ -8,8 +8,6 @@ import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
 describe("dashboardStatusMapping", () => {
   const cases: Array<{
     lifecycle: PolicyLifecycleState;
-    expectedLabel: string;
-    expectedHref: string;
     expectedSteps: {
       IPS: StepStatus;
       RISK: StepStatus;
@@ -19,8 +17,6 @@ describe("dashboardStatusMapping", () => {
   }> = [
     {
       lifecycle: "NO_IPS",
-      expectedLabel: "Set up IPS",
-      expectedHref: "/setup/ips",
       expectedSteps: {
         IPS: "NOT_STARTED",
         RISK: "LOCKED",
@@ -30,8 +26,6 @@ describe("dashboardStatusMapping", () => {
     },
     {
       lifecycle: "IPS_DRAFT",
-      expectedLabel: "Complete IPS",
-      expectedHref: "/setup/ips",
       expectedSteps: {
         IPS: "IN_PROGRESS",
         RISK: "LOCKED",
@@ -41,8 +35,6 @@ describe("dashboardStatusMapping", () => {
     },
     {
       lifecycle: "RISK_PROFILE_MISSING",
-      expectedLabel: "Complete Risk Profile",
-      expectedHref: "/setup/risk-profile",
       expectedSteps: {
         IPS: "COMPLETE",
         RISK: "NOT_STARTED",
@@ -52,8 +44,6 @@ describe("dashboardStatusMapping", () => {
     },
     {
       lifecycle: "RISK_PROFILE_FROZEN",
-      expectedLabel: "Create Guidelines",
-      expectedHref: "/setup/guidelines",
       expectedSteps: {
         IPS: "COMPLETE",
         RISK: "COMPLETE",
@@ -63,8 +53,6 @@ describe("dashboardStatusMapping", () => {
     },
     {
       lifecycle: "GUIDELINES_DERIVED",
-      expectedLabel: "Review Guidelines",
-      expectedHref: "/setup/guidelines",
       expectedSteps: {
         IPS: "COMPLETE",
         RISK: "COMPLETE",
@@ -74,8 +62,6 @@ describe("dashboardStatusMapping", () => {
     },
     {
       lifecycle: "GUIDELINES_COMPILED",
-      expectedLabel: "Go to Decisions",
-      expectedHref: "/decisions",
       expectedSteps: {
         IPS: "COMPLETE",
         RISK: "COMPLETE",
@@ -85,11 +71,9 @@ describe("dashboardStatusMapping", () => {
     },
   ];
 
-  it.each(cases)("returns deterministic model for $lifecycle", ({ lifecycle, expectedLabel, expectedHref, expectedSteps }) => {
+  it.each(cases)("returns deterministic model for $lifecycle", ({ lifecycle, expectedSteps }) => {
     const model = getDashboardModel(lifecycle);
 
-    expect(model.cta.label).toBe(expectedLabel);
-    expect(model.cta.href).toBe(expectedHref);
     expect(model.steps).toEqual(expectedSteps);
   });
 });

--- a/agent/components/DashboardStatus.tsx
+++ b/agent/components/DashboardStatus.tsx
@@ -1,5 +1,6 @@
 import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
 import { getDashboardModel, type StepKey } from "@/components/dashboardStatusMapping";
+import { getNextAction } from "@/lib/lifecycle/nextAction";
 
 const STEP_ROWS: Array<{ key: StepKey; label: string }> = [
   { key: "IPS", label: "IPS" },
@@ -14,6 +15,7 @@ type DashboardStatusProps = {
 
 export default function DashboardStatus({ lifecycleState }: DashboardStatusProps) {
   const model = getDashboardModel(lifecycleState);
+  const nextAction = getNextAction(lifecycleState);
 
   return (
     <section className="card" style={{ padding: 16 }}>
@@ -31,8 +33,8 @@ export default function DashboardStatus({ lifecycleState }: DashboardStatusProps
       </table>
 
       <div style={{ marginTop: 12 }}>
-        <a className="btn btn--primary" href={model.cta.href}>
-          {model.cta.label}
+        <a className="btn btn--primary" href={nextAction.route}>
+          {nextAction.label}
         </a>
       </div>
     </section>

--- a/agent/components/dashboardStatusMapping.ts
+++ b/agent/components/dashboardStatusMapping.ts
@@ -4,14 +4,8 @@ export type StepKey = "IPS" | "RISK" | "GUIDELINES" | "DECISIONS";
 
 export type StepStatus = "NOT_STARTED" | "IN_PROGRESS" | "COMPLETE" | "LOCKED";
 
-export type DashboardCTA = {
-  label: string;
-  href: string;
-};
-
 export type DashboardStateModel = {
   steps: Record<StepKey, StepStatus>;
-  cta: DashboardCTA;
 };
 
 const DASHBOARD_STATE_MODELS: Record<PolicyLifecycleState, DashboardStateModel> = {
@@ -22,10 +16,6 @@ const DASHBOARD_STATE_MODELS: Record<PolicyLifecycleState, DashboardStateModel> 
       GUIDELINES: "LOCKED",
       DECISIONS: "LOCKED",
     },
-    cta: {
-      label: "Set up IPS",
-      href: "/setup/ips",
-    },
   },
   IPS_DRAFT: {
     steps: {
@@ -33,10 +23,6 @@ const DASHBOARD_STATE_MODELS: Record<PolicyLifecycleState, DashboardStateModel> 
       RISK: "LOCKED",
       GUIDELINES: "LOCKED",
       DECISIONS: "LOCKED",
-    },
-    cta: {
-      label: "Complete IPS",
-      href: "/setup/ips",
     },
   },
   RISK_PROFILE_MISSING: {
@@ -46,10 +32,6 @@ const DASHBOARD_STATE_MODELS: Record<PolicyLifecycleState, DashboardStateModel> 
       GUIDELINES: "LOCKED",
       DECISIONS: "LOCKED",
     },
-    cta: {
-      label: "Complete Risk Profile",
-      href: "/setup/risk-profile",
-    },
   },
   RISK_PROFILE_FROZEN: {
     steps: {
@@ -57,10 +39,6 @@ const DASHBOARD_STATE_MODELS: Record<PolicyLifecycleState, DashboardStateModel> 
       RISK: "COMPLETE",
       GUIDELINES: "NOT_STARTED",
       DECISIONS: "LOCKED",
-    },
-    cta: {
-      label: "Create Guidelines",
-      href: "/setup/guidelines",
     },
   },
   GUIDELINES_DERIVED: {
@@ -70,10 +48,6 @@ const DASHBOARD_STATE_MODELS: Record<PolicyLifecycleState, DashboardStateModel> 
       GUIDELINES: "IN_PROGRESS",
       DECISIONS: "LOCKED",
     },
-    cta: {
-      label: "Review Guidelines",
-      href: "/setup/guidelines",
-    },
   },
   GUIDELINES_COMPILED: {
     steps: {
@@ -81,10 +55,6 @@ const DASHBOARD_STATE_MODELS: Record<PolicyLifecycleState, DashboardStateModel> 
       RISK: "COMPLETE",
       GUIDELINES: "COMPLETE",
       DECISIONS: "NOT_STARTED",
-    },
-    cta: {
-      label: "Go to Decisions",
-      href: "/decisions",
     },
   },
 };

--- a/agent/lib/guards/lifecycleGuards.test.ts
+++ b/agent/lib/guards/lifecycleGuards.test.ts
@@ -4,6 +4,7 @@ import {
   canAccessDecisions,
   canAccessGuidelines,
   canAccessRiskProfile,
+  getRedirectForLifecycle,
 } from "@/lib/guards/lifecycleGuards";
 
 describe("lifecycleGuards", () => {
@@ -20,5 +21,9 @@ describe("lifecycleGuards", () => {
   it("enforces guidelines access at or after RISK_PROFILE_FROZEN", () => {
     expect(canAccessGuidelines("RISK_PROFILE_MISSING")).toBe(false);
     expect(canAccessGuidelines("RISK_PROFILE_FROZEN")).toBe(true);
+  });
+
+  it("returns redirect route from lifecycle next-action mapping", () => {
+    expect(getRedirectForLifecycle("RISK_PROFILE_MISSING")).toBe("/setup/risk-profile");
   });
 });

--- a/agent/lib/guards/lifecycleGuards.ts
+++ b/agent/lib/guards/lifecycleGuards.ts
@@ -1,4 +1,5 @@
 import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
+import { getNextAction } from "@/lib/lifecycle/nextAction";
 
 const GUIDELINES_ACCESS_STATES: ReadonlySet<PolicyLifecycleState> = new Set([
   "RISK_PROFILE_FROZEN",
@@ -16,4 +17,8 @@ export function canAccessRiskProfile(state: PolicyLifecycleState): boolean {
 
 export function canAccessGuidelines(state: PolicyLifecycleState): boolean {
   return GUIDELINES_ACCESS_STATES.has(state);
+}
+
+export function getRedirectForLifecycle(state: PolicyLifecycleState): string {
+  return getNextAction(state).route;
 }

--- a/agent/lib/lifecycle/nextAction.test.ts
+++ b/agent/lib/lifecycle/nextAction.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { getNextAction } from "@/lib/lifecycle/nextAction";
+import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
+
+const LIFECYCLE_STATES: readonly PolicyLifecycleState[] = [
+  "NO_IPS",
+  "IPS_DRAFT",
+  "RISK_PROFILE_MISSING",
+  "RISK_PROFILE_FROZEN",
+  "GUIDELINES_DERIVED",
+  "GUIDELINES_COMPILED",
+] as const;
+
+describe("getNextAction", () => {
+  it.each(LIFECYCLE_STATES)("returns non-empty route and label for %s", (state) => {
+    const action = getNextAction(state);
+
+    expect(action.route).toBeTruthy();
+    expect(action.label).toBeTruthy();
+  });
+
+  it("returns expected route for RISK_PROFILE_MISSING", () => {
+    expect(getNextAction("RISK_PROFILE_MISSING").route).toBe("/setup/risk-profile");
+  });
+});

--- a/agent/lib/lifecycle/nextAction.ts
+++ b/agent/lib/lifecycle/nextAction.ts
@@ -1,0 +1,37 @@
+import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
+
+export type NextAction = {
+  route: string;
+  label: string;
+};
+
+const NEXT_ACTION: Record<PolicyLifecycleState, NextAction> = {
+  NO_IPS: {
+    route: "/setup/ips",
+    label: "Set up IPS",
+  },
+  IPS_DRAFT: {
+    route: "/setup/ips",
+    label: "Complete IPS",
+  },
+  RISK_PROFILE_MISSING: {
+    route: "/setup/risk-profile",
+    label: "Complete Risk Profile",
+  },
+  RISK_PROFILE_FROZEN: {
+    route: "/setup/guidelines",
+    label: "Create Guidelines",
+  },
+  GUIDELINES_DERIVED: {
+    route: "/setup/guidelines",
+    label: "Review Guidelines",
+  },
+  GUIDELINES_COMPILED: {
+    route: "/decisions",
+    label: "Go to Decisions",
+  },
+};
+
+export function getNextAction(state: PolicyLifecycleState): NextAction {
+  return NEXT_ACTION[state];
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,6 +48,7 @@
 ## Core Flows
 Lifecycle ordering is explicit: IPS -> Risk Profile -> Portfolio Guidelines -> Executable Policy. Portfolio Guidelines must not be created during IPS setup.
 Lifecycle order is enforced server-side via route guards using the same resolver path as the dashboard.
+Lifecycle next-action routing is centralized in a single mapping used by both the dashboard CTA and server-side route guards.
 ### Canonical Policy Lifecycle Rule (APE)
 
 > **In APE, the Investment Policy Statement (IPS) is established first and independently.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Visiting `/` now performs a server-side redirect to `/dashboard` (dashboard is the default landing route).
 - Chat UI remains reachable at `/chat` (moved from `/`).
 - Server-side route guards enforce lifecycle order for `/decisions`, `/setup/risk-profile`, and `/setup/guidelines` (redirect to `/dashboard` when disallowed).
+- Centralized lifecycle next-action mapping to prevent dashboard/guard routing divergence.
 
 ### Added
 - `/chat` route.


### PR DESCRIPTION
- Introduced lib/lifecycle/nextAction.ts as the single exhaustive lifecycle -> {route,label} mapping.
- Refactored dashboard CTA to use getNextAction(lifecycleState) instead of local CTA strings.
- Added getRedirectForLifecycle in lifecycle guards and switched guarded pages to mapping-based redirects.
- Added tests for mapping exhaustiveness and guard redirect scenario to prevent CTA/guard divergence regressions.
- Updated architecture and changelog docs to record centralized lifecycle next-action routing.