### PR TITLE
chore(app): post-APE-48 hygiene checks

### DIFF
--- a/agent/components/DashboardStatus.test.tsx
+++ b/agent/components/DashboardStatus.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 
 import DashboardStatus from "@/components/DashboardStatus";
 import { getDashboardModel, type StepStatus } from "@/components/dashboardStatusMapping";
+import { getNextAction } from "@/lib/lifecycle/nextAction";
 import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
 
 describe("dashboardStatusMapping", () => {
@@ -80,7 +81,10 @@ describe("dashboardStatusMapping", () => {
 
 describe("DashboardStatus", () => {
   it("renders fixed 4 steps and exactly one CTA link", () => {
-    render(<DashboardStatus lifecycleState="RISK_PROFILE_MISSING" />);
+    const lifecycleState: PolicyLifecycleState = "RISK_PROFILE_MISSING";
+    const nextAction = getNextAction(lifecycleState);
+
+    render(<DashboardStatus lifecycleState={lifecycleState} />);
 
     expect(screen.getByText("IPS")).toBeInTheDocument();
     expect(screen.getByText("Risk Profile")).toBeInTheDocument();
@@ -89,7 +93,7 @@ describe("DashboardStatus", () => {
 
     const links = screen.getAllByRole("link");
     expect(links).toHaveLength(1);
-    expect(links[0]).toHaveTextContent("Complete Risk Profile");
-    expect(links[0]).toHaveAttribute("href", "/setup/risk-profile");
+    expect(links[0]).toHaveTextContent(nextAction.label);
+    expect(links[0]).toHaveAttribute("href", nextAction.route);
   });
 });

--- a/agent/lib/guards/lifecycleGuards.test.ts
+++ b/agent/lib/guards/lifecycleGuards.test.ts
@@ -5,7 +5,9 @@ import {
   canAccessGuidelines,
   canAccessRiskProfile,
   getRedirectForLifecycle,
+  isRouteAllowedForLifecycle,
 } from "@/lib/guards/lifecycleGuards";
+import { getNextAction } from "@/lib/lifecycle/nextAction";
 
 describe("lifecycleGuards", () => {
   it("enforces decisions access only for GUIDELINES_COMPILED", () => {
@@ -24,6 +26,16 @@ describe("lifecycleGuards", () => {
   });
 
   it("returns redirect route from lifecycle next-action mapping", () => {
-    expect(getRedirectForLifecycle("RISK_PROFILE_MISSING")).toBe("/setup/risk-profile");
+    expect(getRedirectForLifecycle("RISK_PROFILE_MISSING")).toBe(getNextAction("RISK_PROFILE_MISSING").route);
+  });
+
+  it("codifies route allow rules for guarded and safe routes", () => {
+    expect(isRouteAllowedForLifecycle("/setup/ips", "NO_IPS")).toBe(true);
+    expect(isRouteAllowedForLifecycle("/dashboard", "NO_IPS")).toBe(true);
+    expect(isRouteAllowedForLifecycle("/chat", "NO_IPS")).toBe(true);
+    expect(isRouteAllowedForLifecycle("/decisions", "GUIDELINES_DERIVED")).toBe(false);
+    expect(isRouteAllowedForLifecycle("/setup/risk-profile", "NO_IPS")).toBe(false);
+    expect(isRouteAllowedForLifecycle("/setup/guidelines", "RISK_PROFILE_MISSING")).toBe(false);
+    expect(isRouteAllowedForLifecycle("/unknown-route", "NO_IPS")).toBe(true);
   });
 });

--- a/agent/lib/guards/lifecycleGuards.ts
+++ b/agent/lib/guards/lifecycleGuards.ts
@@ -19,6 +19,26 @@ export function canAccessGuidelines(state: PolicyLifecycleState): boolean {
   return GUIDELINES_ACCESS_STATES.has(state);
 }
 
+export function isRouteAllowedForLifecycle(route: string, state: PolicyLifecycleState): boolean {
+  if (route === "/decisions") {
+    return canAccessDecisions(state);
+  }
+
+  if (route === "/setup/risk-profile") {
+    return canAccessRiskProfile(state);
+  }
+
+  if (route === "/setup/guidelines") {
+    return canAccessGuidelines(state);
+  }
+
+  if (route === "/setup/ips" || route === "/dashboard" || route === "/chat") {
+    return true;
+  }
+
+  return true;
+}
+
 export function getRedirectForLifecycle(state: PolicyLifecycleState): string {
   return getNextAction(state).route;
 }

--- a/agent/lib/lifecycle/nextAction.test.ts
+++ b/agent/lib/lifecycle/nextAction.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { isRouteAllowedForLifecycle } from "@/lib/guards/lifecycleGuards";
 import { getNextAction } from "@/lib/lifecycle/nextAction";
 import type { PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
 
@@ -20,7 +21,9 @@ describe("getNextAction", () => {
     expect(action.label).toBeTruthy();
   });
 
-  it("returns expected route for RISK_PROFILE_MISSING", () => {
-    expect(getNextAction("RISK_PROFILE_MISSING").route).toBe("/setup/risk-profile");
+  it.each(LIFECYCLE_STATES)("returns a route allowed for the same lifecycle state: %s", (state) => {
+    const { route } = getNextAction(state);
+
+    expect(isRouteAllowedForLifecycle(route, state)).toBe(true);
   });
 });


### PR DESCRIPTION
- Added isRouteAllowedForLifecycle(route, state) to codify lifecycle route access for guarded routes and safe always-allowed routes.
- Added anti-loop invariant test to assert each lifecycle state's getNextAction(state).route is allowed for that same state.
- Refactored dashboard CTA test assertions to read label/route from getNextAction instead of hardcoded CTA strings.
- Updated guard tests to validate the new route-allow helper and mapping-derived redirect target.
- Re-ran grep checks to confirm CTA labels/routes are centralized in lib/lifecycle/nextAction.ts (except allowed guard route identifiers).