### PR TITLE
docs: APE-23 document authoritative decision entry points

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,6 +145,14 @@ NOTE: Do not duplicate this content in other docs. ARCHITECTURE is authoritative
 - Webhooks / inbound: none.
 - File formats / CSV contracts: JSON policy artifacts and markdown governance contracts in `artifacts/`.
 
+## Decision Entry Points (Authoritative)
+- This section is the single source of truth for current decision trigger paths in the repo.
+- Current decision execution entrypoint (verified):
+  - `POST /api/chat` -> `agent/app/api/chat/route.ts` (`POST`) -> `agent/lib/services/decisionService.ts` (`runDecision(...)`)
+  - Current UI caller to that route: `agent/app/chat/page.tsx` -> `agent/components/ChatPage.tsx` (`fetch("/api/chat")`)
+- `POST /api/chat` is the temporary reference contract boundary used for Milestone 1 scenario proofs today, until a GUI-native decision entrypoint exists.
+- `agent/app/dashboard/page.tsx`, `agent/app/setup/ips/page.tsx`, `agent/app/setup/risk-profile/page.tsx`, `agent/app/setup/guidelines/page.tsx`, and `agent/app/decisions/page.tsx` are currently UI shells/lifecycle routing surfaces and do not trigger the decision pipeline yet.
+
 ## Links
 - Decision log: `docs/decisions/`
 - Change log: `docs/CHANGELOG.md`


### PR DESCRIPTION
## Summary
- add an authoritative architecture section listing current decision entry points
- document POST /api/chat as the temporary reference contract boundary for Milestone 1 scenario proofs
- clarify dashboard/setup/decisions pages are UI shells and do not trigger decisions yet

## Testing
- docs-only change
- pre-commit hook ran tests automatically (106 passed)