### PR TITLE
APE-50: harden decision snapshot provenance and evaluation fields for governance inputs

### DIFF
--- a/agent/lib/domain/decisionSnapshot.ts
+++ b/agent/lib/domain/decisionSnapshot.ts
@@ -34,6 +34,18 @@ export interface InputMissing {
   impact: string;
 }
 
+export type SnapshotInputProvenance = "supplied" | "derived" | "missing";
+
+export interface SnapshotInputsProvenance {
+  risk_inputs: SnapshotInputProvenance;
+  authority: SnapshotInputProvenance;
+}
+
+export interface SnapshotInputsEvaluated {
+  risk_inputs: boolean;
+  authority: boolean;
+}
+
 export interface PolicyItemReference {
   dpq_id: string;
   ipm_section_heading?: string;
@@ -89,6 +101,8 @@ export interface DecisionSnapshot {
 
   inputs_observed: InputObserved[];
   inputs_missing: InputMissing[];
+  inputs_provenance: SnapshotInputsProvenance;
+  inputs_evaluated: SnapshotInputsEvaluated;
 
   policy_items_referenced: PolicyItemReference[];
 

--- a/agent/lib/services/decisionService.ts
+++ b/agent/lib/services/decisionService.ts
@@ -421,6 +421,14 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
       outcome_state: "ERROR_NONRECOVERABLE",
       inputs_observed: [],
       inputs_missing: [],
+      inputs_provenance: {
+        risk_inputs: "missing",
+        authority: "missing",
+      },
+      inputs_evaluated: {
+        risk_inputs: false,
+        authority: false,
+      },
       policy_items_referenced: [],
       warnings: [],
       errors: [
@@ -622,6 +630,18 @@ export async function runDecision(req: ChatRequest): Promise<{ snapshot: Decisio
     risk_inputs: riskInputs,
     has_state: !!state,
   });
+  const inputsProvenance = {
+    risk_inputs: req.risk_inputs ? ("supplied" as const) : ("missing" as const),
+    authority: req.authority ? ("supplied" as const) : ("derived" as const),
+  };
+  const inputsEvaluated = {
+    risk_inputs:
+      inputsProvenance.risk_inputs !== "missing" &&
+      typeof riskInputs?.risk_capacity_breached === "boolean" &&
+      typeof riskInputs?.rolling_12m_drawdown_pct === "number" &&
+      Number.isFinite(riskInputs.rolling_12m_drawdown_pct),
+    authority: true,
+  };
 
   const preflightOverride: RecommendationType | null = authorityViolation
     ? "DEFER_AND_REVIEW"
@@ -1080,6 +1100,8 @@ Portfolio state has NOT been provided.
     outcome_state: outcomeState,
     inputs_observed: inputsObserved,
     inputs_missing: outcomeState === "CANNOT_DECIDE_MISSING_INPUTS" ? missingInputs : [],
+    inputs_provenance: inputsProvenance,
+    inputs_evaluated: inputsEvaluated,
     policy_items_referenced: policyItems,
     warnings,
     errors,

--- a/agent/lib/services/decisionSnapshotContract.m3b.test.ts
+++ b/agent/lib/services/decisionSnapshotContract.m3b.test.ts
@@ -104,6 +104,14 @@ describe("Decision Snapshot contract (M3b)", () => {
     expect(typeof evalBlock.drift.bands_breached).toBe("boolean");
 
     expect(evalBlock.correctness.status).toBe("pass");
+    expect(result.snapshot.inputs_provenance).toEqual({
+      risk_inputs: "supplied",
+      authority: "derived",
+    });
+    expect(result.snapshot.inputs_evaluated).toEqual({
+      risk_inputs: true,
+      authority: true,
+    });
   });
 
   it("does not request weights when portfolio_state exists but weights are missing", async () => {
@@ -174,5 +182,17 @@ describe("Decision Snapshot contract (M3b)", () => {
 
     expect(result.snapshot.evaluation.drift.status).toBe("not_applicable");
     expect(result.snapshot.evaluation.correctness.status).toBe("indeterminate");
+    expect(result.snapshot.inputs_provenance).toEqual({
+      risk_inputs: "missing",
+      authority: "derived",
+    });
+    expect(result.snapshot.inputs_evaluated).toEqual({
+      risk_inputs: false,
+      authority: true,
+    });
+    expect(result.snapshot.inputs_provenance.risk_inputs).not.toBeNull();
+    expect(result.snapshot.inputs_provenance.authority).not.toBeNull();
+    expect(typeof result.snapshot.inputs_evaluated.risk_inputs).toBe("boolean");
+    expect(typeof result.snapshot.inputs_evaluated.authority).toBe("boolean");
   });
 });

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,7 +161,7 @@ NOTE: Do not duplicate this content in other docs. ARCHITECTURE is authoritative
 - Mode B (Target) - Server-derived:
   - Target mode only (not implemented today): source of truth for governance inputs is session and/or persisted policy/user state.
   - Contract requirement: snapshot provenance MUST record derivation source and timestamp/identifier when server-derived governance inputs are used.
-  - Current snapshot contract does not yet expose dedicated derivation provenance keys (for example, no explicit `provenance` / `observed_at_boundary` field).
+  - Snapshot contract now exposes machine-addressable governance input status via `inputs_provenance` and `inputs_evaluated`; future server-derived mode still requires derivation source timestamp/identifier details.
 - Missing-input stance (explicit):
   - No silent defaults for governance inputs (`risk_inputs`, `authority`).
   - For Milestone scenario proofs, governance inputs must be explicitly supplied via the canonical decision boundary used by tests.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@
 
 ---
 
+## 2026-02-22 — Iteration APE-50 (Snapshot Auditability Hardening)
+### Changed
+- Decision Snapshot API contract now includes machine-addressable `inputs_provenance` and `inputs_evaluated` fields for `risk_inputs` and `authority`.
+- Snapshot output explicitly records missing governance input status in the new fields without using ambiguous nulls.
+- Decision logic and guardrail outcomes remain unchanged; this is a contract hardening update only.
+
+### Manual regression checks (quick)
+- [ ] Snapshot responses include `inputs_provenance` and `inputs_evaluated` on supplied-input and missing-input paths.
+- [ ] `inputs_evaluated.risk_inputs` is `false` when `risk_inputs` is missing.
+- [ ] Representative scenario decisions (e.g., no-action, risk breach, unauthorized authority) remain unchanged.
+
 ## 2026-02-21 — Default landing route: /dashboard
 ### Changed
 - Visiting `/` now performs a server-side redirect to `/dashboard` (dashboard is the default landing route).


### PR DESCRIPTION
## Summary
- add machine-addressable inputs_provenance and inputs_evaluated fields to Decision Snapshot
- populate deterministic provenance/evaluation status for risk_inputs and authority without changing outcomes
- add contract test assertions and minimal ARCHITECTURE/CHANGELOG updates for the API contract change

## Testing
- npm run test -- lib/services/decisionSnapshotContract.m3b.test.ts
- npm run test
