### PR TITLE
chore(APE-59): tune coverage gates (patch-focused)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Then browse to:
 
 ### Tests (Local)
 
+From the repo root, run coverage with `cd agent && npm run test:coverage`.
+
 From `agent/`:
 
 ```bash

--- a/agent/vitest.config.ts
+++ b/agent/vitest.config.ts
@@ -19,10 +19,14 @@ export default defineConfig({
       reporter: ["text", "html", "lcov"],
       reportsDirectory: "coverage",
       include: ["app/**/*.{ts,tsx}", "components/**/*.{ts,tsx}", "lib/**/*.{ts,tsx}"],
-      lines: 80,
-      functions: 80,
-      statements: 80,
-      branches: 75,
+      // Temporary baseline for APE-59: patch coverage is enforced in Codecov, while local global
+      // thresholds remain a lightweight safety net for the current repo-wide baseline.
+      thresholds: {
+        lines: 70,
+        functions: 80,
+        statements: 70,
+        branches: 78,
+      },
       exclude: [
         "node_modules/",
         ".next/",
@@ -31,7 +35,10 @@ export default defineConfig({
         "**/*.d.ts",
         "**/*.test.{ts,tsx}",
         "**/*.spec.{ts,tsx}",
+        "app/**/page.tsx",
         "app/**/layout.tsx",
+        "**/index.ts",
+        "**/types.ts",
       ],
     }
   }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,22 @@
+# Temporary baseline for APE-59: make PR coverage feedback patch-focused and actionable.
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    patch:
+      default:
+        target: 80%
+        informational: false
+    project:
+      default:
+        informational: true
+
+ignore:
+  # Temporary exclusions for thin framework route wrappers while patch coverage is the primary gate.
+  - "agent/app/**/page.tsx"
+  - "agent/app/**/layout.tsx"
+  # Re-export barrels add noise to project coverage without meaningful execution risk.
+  - "**/index.ts"
+  # Type declarations/interfaces do not contain executable runtime logic.
+  - "agent/**/types.ts"


### PR DESCRIPTION
## Summary

- add repo-root Codecov policy with patch coverage as the primary enforced signal\n- make project coverage informational (non-blocking) for the temporary baseline
- fix Vitest coverage threshold enforcement by using coverage.thresholds
- document local coverage run command from repo root
 
## Notes
- temporary exclusions are narrow and documented (page/layout wrappers, barrel files, type-only files)
- no broad test additions in this slice
