### PR TITLE
chore(APE-59): enforce type-only exports in types.ts files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
           cache-dependency-path: agent/package-lock.json
       - name: Install dependencies
         run: npm ci
+      - name: Run type-file guardrail
+        run: npm run check:types-type-only
       - name: Lint
         run: npm run lint
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Then browse to:
 ### Tests (Local)
 
 From the repo root, run coverage with `cd agent && npm run test:coverage`.
+Type-only file guardrail (local): `cd agent && npm run check:types-type-only`.
 
 From `agent/`:
 

--- a/agent/package.json
+++ b/agent/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "check:types-type-only": "node ./scripts/check-types-files-type-only.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/agent/scripts/check-types-files-type-only.mjs
+++ b/agent/scripts/check-types-files-type-only.mjs
@@ -1,0 +1,122 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const SKIP_DIRS = new Set(["node_modules", ".next", "coverage", ".git"]);
+const TYPE_FILE_SUFFIX = `${path.sep}types.ts`;
+
+async function walk(dir, acc) {
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) {
+        continue;
+      }
+      await walk(path.join(dir, entry.name), acc);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      const fullPath = path.join(dir, entry.name);
+      if (fullPath.endsWith(TYPE_FILE_SUFFIX)) {
+        acc.push(fullPath);
+      }
+    }
+  }
+}
+
+function stripInlineComment(line) {
+  const idx = line.indexOf("//");
+  return idx >= 0 ? line.slice(0, idx) : line;
+}
+
+function isIgnoredLine(line) {
+  const trimmed = line.trim();
+  return (
+    trimmed.length === 0 ||
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("/*") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("*/")
+  );
+}
+
+function findViolations(content) {
+  const lines = content.split(/\r?\n/);
+  const violations = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const originalLine = lines[i];
+    if (isIgnoredLine(originalLine)) {
+      continue;
+    }
+
+    const line = stripInlineComment(originalLine).trim();
+    if (!line.startsWith("export")) {
+      continue;
+    }
+
+    // Allowed type-only export forms.
+    if (/^export\s+type\b/.test(line) || /^export\s+interface\b/.test(line)) {
+      continue;
+    }
+
+    // Explicit type-only re-exports are allowed.
+    if (/^export\s+type\s*\{/.test(line)) {
+      continue;
+    }
+
+    // Runtime-risk exports in a types.ts file.
+    if (
+      /^export\s+default\b/.test(line) ||
+      /^export\s+(const|let|var|function|async\s+function|class|enum)\b/.test(line) ||
+      /^export\s*\{/.test(line)
+    ) {
+      violations.push({
+        line: i + 1,
+        snippet: originalLine.trim(),
+      });
+    }
+  }
+
+  return violations;
+}
+
+async function main() {
+  const files = [];
+  await walk(ROOT, files);
+  files.sort();
+
+  const allViolations = [];
+
+  for (const file of files) {
+    const content = await readFile(file, "utf8");
+    const violations = findViolations(content);
+    if (violations.length > 0) {
+      allViolations.push({
+        file: path.relative(ROOT, file),
+        violations,
+      });
+    }
+  }
+
+  if (allViolations.length > 0) {
+    console.error("types.ts type-only guardrail failed:");
+    for (const result of allViolations) {
+      console.error(`- ${result.file}`);
+      for (const violation of result.violations) {
+        console.error(`  line ${violation.line}: ${violation.snippet}`);
+      }
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`types.ts type-only guardrail passed (${files.length} file(s) checked).`);
+}
+
+main().catch((error) => {
+  console.error("types.ts type-only guardrail crashed:", error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a CI/local guardrail to keep `agent/**/types.ts` files type-only
- protect the safety of the existing Codecov ignore rule for `agent/**/types.ts`
- add a reusable local command and CI step before lint/tests

## What changed
- New script: `agent/scripts/check-types-files-type-only.mjs`
- New npm script: `cd agent && npm run check:types-type-only`
- CI step in `.github/workflows/tests.yml` to run the guardrail before lint/tests
- README note for local discoverability

## Why this exists
`agent/**/types.ts` is currently ignored in Codecov. That is only safe while those files remain type-only.
This PR prevents runtime exports (for example `export const`, `export enum`, `export function`, non-type re-exports) from silently creeping into those files.

## Validation
- `cd agent && npm run check:types-type-only` ✅
- `cd agent && npm run lint` ✅ (existing warnings only from generated `coverage/` files)
- `cd agent && npm run test` ✅

## Notes
- No runtime behavior changes
- No Codecov policy changes
- Tooling/CI guardrail only