### PR TITLE
APE-53: Add POST /api/ips save draft API (server-first)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Branch Safety (Mandatory)
+- NEVER implement code changes while checked out on `develop`.
+- Before making any edits, run a branch check (for example, `git branch --show-current`).
+- Before committing, run a branch check again.
+- If the current branch is `develop`, create/switch to a feature branch before editing any files.
+- If work starts on `develop` by mistake, immediately create/switch to a feature branch and carry uncommitted changes over; do not continue coding on `develop`.
+- If no branch name is provided, use the repo-enforced format `<type>/APE-<id>-<short-slug>` (for example, `feat/APE-53-ips-save-draft`).
+
+## Implementation Process
+- Before editing, inspect existing patterns in the repo (route handlers, error responses, tests, dependency injection style) and follow them unless the story requires a new pattern.
+- Run targeted tests for the changed scope first.
+- Run the repo-standard full test command before final handoff when feasible.
+- If tests cannot run, state the exact command attempted, the exact failure, and whether the issue is code-related or environment/setup-related.
+
+## Docs Consistency Check
+- Include a Doc Impact Check in the final summary for every story: `ARCHITECTURE` / `CHANGELOG` / `ADR` with yes/no and a one-line reason for each.
+- Do not create/update `docs/ARCHITECTURE.md` or `docs/decisions/*` unless the story materially changes system structure, invariants, or durable architectural decisions.
+- Update `docs/CHANGELOG.md` when behavior/API/runtime configuration/enforcement changes are user-visible or contract-visible.
+- Keep changelog entries factual and concise; do not include internal file paths.
+
+## Communication
+- In final handoff, confirm the current branch name.
+- Prefer user-facing wording in docs/changelog; keep internal implementation terms (for example, `upsert`) to code-level APIs when possible.
+
+## Standing Instruction
+- Treat this file as a standing instruction for all future story implementation work in this repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,5 +24,10 @@
 - In final handoff, confirm the current branch name.
 - Prefer user-facing wording in docs/changelog; keep internal implementation terms (for example, `upsert`) to code-level APIs when possible.
 
+## PR Workflow (Repo-Specific)
+- This repo opens PRs against `harishkamathuk/ape` with base branch `develop`.
+- Prefer `gh prd` (GitHub CLI alias) for PR creation, which expands to `gh pr create -R harishkamathuk/ape --base develop`.
+- Push feature branches to `origin` (fork), not `upstream`.
+
 ## Standing Instruction
 - Treat this file as a standing instruction for all future story implementation work in this repo.

--- a/agent/app/api/ips/route.test.ts
+++ b/agent/app/api/ips/route.test.ts
@@ -89,6 +89,35 @@ describe("POST /api/ips", () => {
     expect(policyRepo.upsertIps).not.toHaveBeenCalled();
   });
 
+  it("returns 400 with unknown field details and does not call repo", async () => {
+    const userProvider = createUserProvider("u123");
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({ userProvider, policyRepo });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ...createValidDraft(),
+          extraField: "nope",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Request body contains unsupported fields.",
+        details: {
+          unknownFields: ["extraField"],
+        },
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
   it("maps known repo invalid-userId errors to 400", async () => {
     const userProvider = createUserProvider("bad/user");
     const policyRepo = createPolicyRepo({
@@ -114,6 +143,62 @@ describe("POST /api/ips", () => {
         message: "Invalid user identifier.",
       },
     });
+  });
+
+  it("returns 401 when user context is unavailable", async () => {
+    const userProvider: UserContextProvider = {
+      getCurrentUser: vi.fn(() => {
+        throw new Error("auth unavailable");
+      }),
+    };
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({ userProvider, policyRepo });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createValidDraft()),
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "UNAUTHORIZED",
+        message: "User context unavailable.",
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 for unexpected repository errors without leaking details", async () => {
+    const policyRepo = createPolicyRepo({
+      upsertIps: vi.fn(async () => {
+        throw new Error("disk exploded");
+      }),
+    });
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createValidDraft()),
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "INTERNAL",
+        message: "Internal error",
+      },
+    });
+    expect(policyRepo.upsertIps).toHaveBeenCalledTimes(1);
   });
 
   it("returns 400 when request body is malformed JSON", async () => {

--- a/agent/app/api/ips/route.test.ts
+++ b/agent/app/api/ips/route.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPostHandler } from "@/app/api/ips/route";
+import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
+import type { IpsInstance, PolicyState } from "@/lib/policy/types";
+import type { UserContextProvider } from "@/lib/user/UserContextProvider";
+import type { User } from "@/lib/user/types";
+
+function createValidDraft(overrides: Partial<IpsInstance> = {}): IpsInstance {
+  return {
+    ipsVersion: "v1",
+    ipsSha256: "abc123",
+    status: "DRAFT",
+    createdAtIso: "2026-02-22T00:00:00.000Z",
+    content: "IPS draft content",
+    ...overrides,
+  };
+}
+
+function createUserProvider(userId = "u123"): UserContextProvider {
+  const getCurrentUser = vi.fn<() => User>(() => ({
+    userId,
+    displayName: "User 123",
+    authType: "LOCAL_FAKE",
+  }));
+
+  return { getCurrentUser };
+}
+
+function createPolicyRepo(overrides: Partial<PolicyStateRepository> = {}): PolicyStateRepository {
+  return {
+    getPolicyState: vi.fn<(userId: string) => Promise<PolicyState | null>>(async () => null),
+    upsertIps: vi.fn<(userId: string, ips: IpsInstance) => Promise<void>>(async () => undefined),
+    upsertRiskProfile: vi.fn(async () => undefined),
+    upsertGuidelines: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe("POST /api/ips", () => {
+  it("saves a valid IPS draft for the current user", async () => {
+    const userProvider = createUserProvider("u123");
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({ userProvider, policyRepo });
+    const payload = createValidDraft();
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "DRAFT" });
+    expect(userProvider.getCurrentUser).toHaveBeenCalledTimes(1);
+    expect(policyRepo.upsertIps).toHaveBeenCalledTimes(1);
+    expect(policyRepo.upsertIps).toHaveBeenCalledWith("u123", {
+      ipsVersion: "v1",
+      ipsSha256: "abc123",
+      status: "DRAFT",
+      createdAtIso: "2026-02-22T00:00:00.000Z",
+      content: "IPS draft content",
+    });
+  });
+
+  it("returns 400 and does not call repo when validation fails", async () => {
+    const userProvider = createUserProvider("u123");
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({ userProvider, policyRepo });
+    const payload = createValidDraft({ status: "FROZEN" });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Field 'status' must be 'DRAFT' for this endpoint.",
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("maps known repo invalid-userId errors to 400", async () => {
+    const userProvider = createUserProvider("bad/user");
+    const policyRepo = createPolicyRepo({
+      upsertIps: vi.fn(async () => {
+        throw new Error("Invalid userId format: bad/user");
+      }),
+    });
+    const handler = createPostHandler({ userProvider, policyRepo });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(createValidDraft()),
+      }),
+    );
+
+    expect(policyRepo.upsertIps).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Invalid user identifier.",
+      },
+    });
+  });
+
+  it("returns 400 when request body is malformed JSON", async () => {
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{bad-json",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Request body must be valid JSON.",
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+});

--- a/agent/app/api/ips/route.ts
+++ b/agent/app/api/ips/route.ts
@@ -1,0 +1,147 @@
+import { NextResponse } from "next/server";
+
+import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
+import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
+import type { IpsInstance } from "@/lib/policy/types";
+import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
+import type { UserContextProvider } from "@/lib/user/UserContextProvider";
+
+type IpsRouteDeps = {
+  userProvider?: UserContextProvider;
+  policyRepo?: PolicyStateRepository;
+};
+
+type ApiErrorBody = {
+  error: {
+    code: "BAD_REQUEST" | "UNAUTHORIZED" | "INTERNAL";
+    message: string;
+    details?: unknown;
+  };
+};
+
+type ValidationResult =
+  | { ok: true; value: IpsInstance & { status: "DRAFT" } }
+  | { ok: false; message: string; details?: unknown };
+
+const ALLOWED_KEYS = ["ipsVersion", "ipsSha256", "status", "createdAtIso", "content"] as const;
+
+function errorResponse(
+  status: number,
+  code: ApiErrorBody["error"]["code"],
+  message: string,
+  details?: unknown,
+): NextResponse<ApiErrorBody> {
+  return NextResponse.json(
+    {
+      error: {
+        code,
+        message,
+        ...(details === undefined ? {} : { details }),
+      },
+    },
+    { status },
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function validateIpsDraftPayload(body: unknown): ValidationResult {
+  if (!isPlainObject(body)) {
+    return { ok: false, message: "Request body must be an object." };
+  }
+
+  const keys = Object.keys(body);
+  const unknownKeys = keys.filter((key) => !ALLOWED_KEYS.includes(key as (typeof ALLOWED_KEYS)[number]));
+  if (unknownKeys.length > 0) {
+    return {
+      ok: false,
+      message: "Request body contains unsupported fields.",
+      details: { unknownFields: unknownKeys },
+    };
+  }
+
+  const ipsVersion = body.ipsVersion;
+  if (typeof ipsVersion !== "string" || ipsVersion.trim() === "") {
+    return { ok: false, message: "Field 'ipsVersion' must be a non-empty string." };
+  }
+
+  const ipsSha256 = body.ipsSha256;
+  if (typeof ipsSha256 !== "string" || ipsSha256.trim() === "") {
+    return { ok: false, message: "Field 'ipsSha256' must be a non-empty string." };
+  }
+
+  const status = body.status;
+  if (status !== "DRAFT") {
+    return { ok: false, message: "Field 'status' must be 'DRAFT' for this endpoint." };
+  }
+
+  const createdAtIso = body.createdAtIso;
+  if (typeof createdAtIso !== "string" || createdAtIso.trim() === "") {
+    return { ok: false, message: "Field 'createdAtIso' must be a non-empty string." };
+  }
+
+  const content = body.content;
+  if (typeof content !== "string" || content.trim() === "") {
+    return { ok: false, message: "Field 'content' must be a non-empty string." };
+  }
+
+  return {
+    ok: true,
+    value: {
+      ipsVersion,
+      ipsSha256,
+      status: "DRAFT",
+      createdAtIso,
+      content,
+    },
+  };
+}
+
+function mapUnexpectedError(err: unknown): NextResponse<ApiErrorBody> {
+  if (err instanceof Error && err.message.includes("Invalid userId format")) {
+    return errorResponse(400, "BAD_REQUEST", "Invalid user identifier.");
+  }
+
+  return errorResponse(500, "INTERNAL", "Internal error");
+}
+
+export function createPostHandler(deps: IpsRouteDeps = {}) {
+  return async function POST(req: Request) {
+    let rawBody: unknown;
+    try {
+      rawBody = await req.json();
+    } catch {
+      return errorResponse(400, "BAD_REQUEST", "Request body must be valid JSON.");
+    }
+
+    const validated = validateIpsDraftPayload(rawBody);
+    if (!validated.ok) {
+      return errorResponse(400, "BAD_REQUEST", validated.message, validated.details);
+    }
+
+    const userProvider = deps.userProvider ?? new LocalUserContextProvider();
+    const policyRepo = deps.policyRepo ?? new JsonPolicyStateRepository();
+
+    let userId: string | undefined;
+    try {
+      userId = userProvider.getCurrentUser()?.userId;
+    } catch {
+      return errorResponse(401, "UNAUTHORIZED", "User context unavailable.");
+    }
+
+    if (typeof userId !== "string" || userId.trim() === "") {
+      return errorResponse(401, "UNAUTHORIZED", "User context unavailable.");
+    }
+
+    try {
+      await policyRepo.upsertIps(userId, validated.value);
+      return NextResponse.json({ status: validated.value.status });
+    } catch (err) {
+      return mapUnexpectedError(err);
+    }
+  };
+}
+
+export const POST = createPostHandler();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,15 @@
 
 ---
 
+## 2026-02-22 — Iteration APE-53 (IPS Draft Save API)
+### Added
+- Added `POST /api/ips` to save (create/update) an IPS draft for the current user with explicit request validation and predictable error responses.
+
+### Manual regression checks (quick)
+- [ ] `curl -s -X POST http://localhost:3000/api/ips -H "Content-Type: application/json" --data "{\"ipsVersion\":\"v1\",\"ipsSha256\":\"abc123\",\"status\":\"DRAFT\",\"createdAtIso\":\"2026-02-22T00:00:00.000Z\",\"content\":\"IPS draft\"}"` returns `200` with `{"status":"DRAFT"}`.
+- [ ] `curl -s -X POST http://localhost:3000/api/ips -H "Content-Type: application/json" --data "{\"ipsVersion\":\"v1\",\"ipsSha256\":\"abc123\",\"status\":\"FROZEN\",\"createdAtIso\":\"2026-02-22T00:00:00.000Z\",\"content\":\"IPS draft\"}"` returns `400` with `error.code = "BAD_REQUEST"`.
+- [ ] `curl -s -X POST http://localhost:3000/api/ips -H "Content-Type: application/json" --data "{\"ipsVersion\":\"v1\"}"` returns `400` with `error.code = "BAD_REQUEST"`.
+
 ## 2026-02-22 — Iteration APE-50 (Snapshot Auditability Hardening)
 ### Changed
 - Decision Snapshot API contract now includes machine-addressable `inputs_provenance` and `inputs_evaluated` fields for `risk_inputs` and `authority`.


### PR DESCRIPTION
## Summary
- add `POST /api/ips` route handler to save (create/update) IPS drafts for the current user
- validate an explicit `IpsInstance`-shaped draft payload (`status` must be `DRAFT`) and return structured API errors
- add route unit tests and changelog entry for the new API behavior
- add repo `AGENTS.md` branch-safety and process rules (including no coding on `develop`)

## Implementation details
- resolves `userId` via `LocalUserContextProvider` / `UserContextProvider`
- calls `PolicyStateRepository.upsertIps(userId, ipsDraft)` exactly once on the happy path
- returns `200` with `{ "status": "DRAFT" }`
- maps known repo/storage invalid userId errors to `400 BAD_REQUEST`
- returns `401 UNAUTHORIZED` for missing user context and `500 INTERNAL` for unexpected errors

## Tests
- `cd agent && npm test -- app/api/ips/route.test.ts`
- `cd agent && npm test`

## Docs impact
- `ARCHITECTURE`: no (no system shape/boundary/invariant change)
- `CHANGELOG`: yes (new API behavior/contract)
- `ADR`: no (no durable architectural decision introduced)
