### PR TITLE
APE-54: Add IPS freeze API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,23 @@
 
 ## Standing Instruction
 - Treat this file as a standing instruction for all future story implementation work in this repo.
+
+## End of PR flow
+
+- You have finished implementing the current story on a feature branch.
+
+- Do the following in order, stopping after each step and waiting for my explicit “continue”:
+- For step 2, use `gh prd` to open the PR (repo default: base `develop` on `harishkamathuk/ape`).
+
+1) Push the feature branch to origin (if not already pushed).
+2) Open a PR into `develop` (use a clear title + bullet summary + testing notes).
+3) Pause for me to review the PR.
+4) After my review, add/adjust PR description and leave PR comments where relevant (review notes, risks, follow-ups).
+5) Pause again.
+6) If the PR is safe (CI green + approvals + no unresolved threads), merge it using the standard repo method (squash or merge-commit—match existing convention).
+7) Pause again.
+8) Delete the feature branch from origin and locally.
+9) Checkout `develop`, pull latest, and confirm clean status.
+
+- At each pause: print what you did, links/commands used, and what’s next.
+- Do not merge or delete anything without my explicit “continue”.

--- a/agent/app/api/ips/freeze/route.test.ts
+++ b/agent/app/api/ips/freeze/route.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createPostHandler } from "@/app/api/ips/freeze/route";
+import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
+import type { IpsInstance, PolicyState } from "@/lib/policy/types";
+import type { UserContextProvider } from "@/lib/user/UserContextProvider";
+import type { User } from "@/lib/user/types";
+
+function createIps(overrides: Partial<IpsInstance> = {}): IpsInstance {
+  return {
+    ipsVersion: "v1",
+    ipsSha256: "abc123",
+    status: "DRAFT",
+    createdAtIso: "2026-02-22T00:00:00.000Z",
+    content: "IPS draft content",
+    ...overrides,
+  };
+}
+
+function createUserProvider(userId = "u123"): UserContextProvider {
+  const getCurrentUser = vi.fn<() => User>(() => ({
+    userId,
+    displayName: "User 123",
+    authType: "LOCAL_FAKE",
+  }));
+
+  return { getCurrentUser };
+}
+
+function createPolicyRepo(overrides: Partial<PolicyStateRepository> = {}): PolicyStateRepository {
+  return {
+    getPolicyState: vi.fn<(userId: string) => Promise<PolicyState | null>>(async () => null),
+    upsertIps: vi.fn<(userId: string, ips: IpsInstance) => Promise<void>>(async () => undefined),
+    upsertRiskProfile: vi.fn(async () => undefined),
+    upsertGuidelines: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe("POST /api/ips/freeze", () => {
+  it("freezes a draft IPS for the current user", async () => {
+    const draftIps = createIps({ status: "DRAFT" });
+    const userProvider = createUserProvider("u123");
+    const policyRepo = createPolicyRepo({
+      getPolicyState: vi.fn(async () => ({
+        userId: "u123",
+        ips: draftIps,
+      })),
+    });
+    const handler = createPostHandler({ userProvider, policyRepo });
+
+    const response = await handler(new Request("http://localhost/api/ips/freeze", { method: "POST" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "FROZEN" });
+    expect(userProvider.getCurrentUser).toHaveBeenCalledTimes(1);
+    expect(policyRepo.getPolicyState).toHaveBeenCalledTimes(1);
+    expect(policyRepo.getPolicyState).toHaveBeenCalledWith("u123");
+    expect(policyRepo.upsertIps).toHaveBeenCalledTimes(1);
+    expect(policyRepo.upsertIps).toHaveBeenCalledWith("u123", {
+      ...draftIps,
+      status: "FROZEN",
+    });
+  });
+
+  it("returns 409 when no IPS draft exists", async () => {
+    const policyRepo = createPolicyRepo({
+      getPolicyState: vi.fn(async () => null),
+    });
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(new Request("http://localhost/api/ips/freeze", { method: "POST" }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "CONFLICT",
+        message: "No IPS draft exists to freeze.",
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 idempotent success when IPS is already frozen", async () => {
+    const policyRepo = createPolicyRepo({
+      getPolicyState: vi.fn(async () => ({
+        userId: "u123",
+        ips: createIps({ status: "FROZEN" }),
+      })),
+    });
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(new Request("http://localhost/api/ips/freeze", { method: "POST" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "FROZEN" });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when user context is unavailable", async () => {
+    const userProvider: UserContextProvider = {
+      getCurrentUser: vi.fn(() => {
+        throw new Error("auth unavailable");
+      }),
+    };
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({ userProvider, policyRepo });
+
+    const response = await handler(new Request("http://localhost/api/ips/freeze", { method: "POST" }));
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "UNAUTHORIZED",
+        message: "User context unavailable.",
+      },
+    });
+    expect(policyRepo.getPolicyState).not.toHaveBeenCalled();
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when request body is malformed JSON", async () => {
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips/freeze", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{bad-json",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Request body must be valid JSON.",
+      },
+    });
+    expect(policyRepo.getPolicyState).not.toHaveBeenCalled();
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when request body contains unsupported fields", async () => {
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips/freeze", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ status: "FROZEN" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Request body contains unsupported fields.",
+        details: {
+          unknownFields: ["status"],
+        },
+      },
+    });
+    expect(policyRepo.getPolicyState).not.toHaveBeenCalled();
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("maps known repo invalid-userId errors to 400", async () => {
+    const policyRepo = createPolicyRepo({
+      getPolicyState: vi.fn(async () => ({
+        userId: "bad/user",
+        ips: createIps({ status: "DRAFT" }),
+      })),
+      upsertIps: vi.fn(async () => {
+        throw new Error("Invalid userId format: bad/user");
+      }),
+    });
+    const handler = createPostHandler({
+      userProvider: createUserProvider("bad/user"),
+      policyRepo,
+    });
+
+    const response = await handler(new Request("http://localhost/api/ips/freeze", { method: "POST" }));
+
+    expect(policyRepo.getPolicyState).toHaveBeenCalledTimes(1);
+    expect(policyRepo.upsertIps).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Invalid user identifier.",
+      },
+    });
+  });
+
+  it("returns 500 for unexpected repository errors without leaking details", async () => {
+    const policyRepo = createPolicyRepo({
+      getPolicyState: vi.fn(async () => {
+        throw new Error("disk exploded");
+      }),
+    });
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(new Request("http://localhost/api/ips/freeze", { method: "POST" }));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "INTERNAL",
+        message: "Internal error",
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+});

--- a/agent/app/api/ips/freeze/route.test.ts
+++ b/agent/app/api/ips/freeze/route.test.ts
@@ -85,10 +85,11 @@ describe("POST /api/ips/freeze", () => {
   });
 
   it("returns 200 idempotent success when IPS is already frozen", async () => {
+    const frozenIps = createIps({ status: "FROZEN" });
     const policyRepo = createPolicyRepo({
       getPolicyState: vi.fn(async () => ({
         userId: "u123",
-        ips: createIps({ status: "FROZEN" }),
+        ips: frozenIps,
       })),
     });
     const handler = createPostHandler({
@@ -101,6 +102,37 @@ describe("POST /api/ips/freeze", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ status: "FROZEN" });
     expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+    expect(frozenIps.status).toBe("FROZEN");
+  });
+
+  it("treats empty JSON object body as no-args command input", async () => {
+    const draftIps = createIps({ status: "DRAFT" });
+    const policyRepo = createPolicyRepo({
+      getPolicyState: vi.fn(async () => ({
+        userId: "u123",
+        ips: draftIps,
+      })),
+    });
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips/freeze", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "FROZEN" });
+    expect(policyRepo.upsertIps).toHaveBeenCalledTimes(1);
+    expect(policyRepo.upsertIps).toHaveBeenCalledWith("u123", {
+      ...draftIps,
+      status: "FROZEN",
+    });
   });
 
   it("returns 401 when user context is unavailable", async () => {
@@ -162,7 +194,7 @@ describe("POST /api/ips/freeze", () => {
       new Request("http://localhost/api/ips/freeze", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ status: "FROZEN" }),
+        body: JSON.stringify({ foo: "bar" }),
       }),
     );
 
@@ -172,11 +204,34 @@ describe("POST /api/ips/freeze", () => {
         code: "BAD_REQUEST",
         message: "Request body contains unsupported fields.",
         details: {
-          unknownFields: ["status"],
+          unknownFields: ["foo"],
         },
       },
     });
     expect(policyRepo.getPolicyState).not.toHaveBeenCalled();
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when policy state exists but IPS is missing", async () => {
+    const policyRepo = createPolicyRepo({
+      getPolicyState: vi.fn(async () => ({
+        userId: "u123",
+      })),
+    });
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(new Request("http://localhost/api/ips/freeze", { method: "POST" }));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "CONFLICT",
+        message: "No IPS draft exists to freeze.",
+      },
+    });
     expect(policyRepo.upsertIps).not.toHaveBeenCalled();
   });
 

--- a/agent/app/api/ips/freeze/route.ts
+++ b/agent/app/api/ips/freeze/route.ts
@@ -1,0 +1,139 @@
+import { NextResponse } from "next/server";
+
+import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
+import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
+import type { IpsInstance } from "@/lib/policy/types";
+import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
+import type { UserContextProvider } from "@/lib/user/UserContextProvider";
+
+type IpsFreezeRouteDeps = {
+  userProvider?: UserContextProvider;
+  policyRepo?: PolicyStateRepository;
+};
+
+type ApiErrorBody = {
+  error: {
+    code: "BAD_REQUEST" | "UNAUTHORIZED" | "CONFLICT" | "INTERNAL";
+    message: string;
+    details?: unknown;
+  };
+};
+
+type EmptyBodyValidationResult =
+  | { ok: true }
+  | { ok: false; message: string; details?: unknown };
+
+function errorResponse(
+  status: number,
+  code: ApiErrorBody["error"]["code"],
+  message: string,
+  details?: unknown,
+): NextResponse<ApiErrorBody> {
+  return NextResponse.json(
+    {
+      error: {
+        code,
+        message,
+        ...(details === undefined ? {} : { details }),
+      },
+    },
+    { status },
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function validateCommandBody(req: Request): Promise<EmptyBodyValidationResult> {
+  let rawText: string;
+  try {
+    rawText = await req.text();
+  } catch {
+    return { ok: false, message: "Request body must be valid JSON." };
+  }
+
+  if (rawText.trim() === "") {
+    return { ok: true };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    return { ok: false, message: "Request body must be valid JSON." };
+  }
+
+  if (!isPlainObject(parsed)) {
+    return { ok: false, message: "Request body must be an object." };
+  }
+
+  const unknownFields = Object.keys(parsed);
+  if (unknownFields.length > 0) {
+    return {
+      ok: false,
+      message: "Request body contains unsupported fields.",
+      details: { unknownFields },
+    };
+  }
+
+  return { ok: true };
+}
+
+function mapUnexpectedError(err: unknown): NextResponse<ApiErrorBody> {
+  if (err instanceof Error && err.message.includes("Invalid userId format")) {
+    return errorResponse(400, "BAD_REQUEST", "Invalid user identifier.");
+  }
+
+  return errorResponse(500, "INTERNAL", "Internal error");
+}
+
+function freezeIps(ips: IpsInstance): IpsInstance {
+  return {
+    ...ips,
+    status: "FROZEN",
+  };
+}
+
+export function createPostHandler(deps: IpsFreezeRouteDeps = {}) {
+  return async function POST(req: Request) {
+    const bodyValidation = await validateCommandBody(req);
+    if (!bodyValidation.ok) {
+      return errorResponse(400, "BAD_REQUEST", bodyValidation.message, bodyValidation.details);
+    }
+
+    const userProvider = deps.userProvider ?? new LocalUserContextProvider();
+    const policyRepo = deps.policyRepo ?? new JsonPolicyStateRepository();
+
+    let userId: string | undefined;
+    try {
+      userId = userProvider.getCurrentUser()?.userId;
+    } catch {
+      return errorResponse(401, "UNAUTHORIZED", "User context unavailable.");
+    }
+
+    if (typeof userId !== "string" || userId.trim() === "") {
+      return errorResponse(401, "UNAUTHORIZED", "User context unavailable.");
+    }
+
+    try {
+      const policyState = await policyRepo.getPolicyState(userId);
+      const currentIps = policyState?.ips;
+
+      if (!currentIps) {
+        return errorResponse(409, "CONFLICT", "No IPS draft exists to freeze.");
+      }
+
+      if (currentIps.status === "FROZEN") {
+        return NextResponse.json({ status: "FROZEN" });
+      }
+
+      await policyRepo.upsertIps(userId, freezeIps(currentIps));
+      return NextResponse.json({ status: "FROZEN" });
+    } catch (err) {
+      return mapUnexpectedError(err);
+    }
+  };
+}
+
+export const POST = createPostHandler();

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ---
 
+## 2026-02-22 — Iteration APE-54 (IPS Freeze API)
+### Added
+- Added `POST /api/ips/freeze` to transition the current user’s IPS from `DRAFT` to `FROZEN` with deterministic state handling.
+- Freeze returns `409` when no IPS draft exists and returns idempotent `200` when the IPS is already frozen.
+
+### Manual regression checks (quick)
+- [ ] `POST /api/ips/freeze` after saving a draft returns `200` with `{"status":"FROZEN"}`.
+- [ ] `POST /api/ips/freeze` with no existing IPS draft returns `409` with `error.code = "CONFLICT"`.
+- [ ] Repeating `POST /api/ips/freeze` after freeze returns `200` with `{"status":"FROZEN"}` and no content changes.
+
 ## 2026-02-22 — Iteration APE-53 (IPS Draft Save API)
 ### Added
 - Added `POST /api/ips` to save (create/update) an IPS draft for the current user with explicit request validation and predictable error responses.


### PR DESCRIPTION
## Summary\n- add POST /api/ips/freeze to transition current user IPS from DRAFT to FROZEN\n- enforce deterministic state handling (409 when no IPS draft, idempotent 200 when already frozen)\n- add route tests for happy path, conflict/idempotent cases, malformed JSON, unsupported fields, auth failures, and repo error mapping\n- add edge-case tests validating empty body / {} command input and policy-state-without-IPS conflict behavior\n- update changelog for the new API endpoint\n\n## Testing\n- cd agent && npm test -- app/api/ips/freeze/route.test.ts\n- cd agent && npm test\n\n## Notes\n- Follow-up commit includes test-only validation of empty body and idempotent non-upsert behavior; no route semantic change was required.