### PR TITLE
APE-55: Make dashboard lifecycle reflect persisted IPS state

### DIFF
--- a/agent/app/dashboard/page.tsx
+++ b/agent/app/dashboard/page.tsx
@@ -2,11 +2,12 @@ import DashboardStatus from "@/components/DashboardStatus";
 import { loadDashboardLifecycle } from "@/lib/dashboard/loadDashboardLifecycle";
 
 export default async function DashboardPage() {
-  const { lifecycleState } = await loadDashboardLifecycle();
+  const { lifecycleState, nextAction } = await loadDashboardLifecycle();
 
   return (
     <main className="app">
-      <p>Lifecycle: {lifecycleState}</p>
+      <p data-testid="dashboard-lifecycle-state">Lifecycle: {lifecycleState}</p>
+      <p data-testid="dashboard-next-cta-route">Next CTA route: {nextAction.route}</p>
       <DashboardStatus lifecycleState={lifecycleState} />
     </main>
   );

--- a/agent/lib/dashboard/loadDashboardLifecycle.test.ts
+++ b/agent/lib/dashboard/loadDashboardLifecycle.test.ts
@@ -31,10 +31,14 @@ describe("loadDashboardLifecycle", () => {
     expect(result).toEqual({
       userId: "u123",
       lifecycleState: "NO_IPS",
+      nextAction: {
+        route: "/setup/ips",
+        label: "Set up IPS",
+      },
     });
   });
 
-  it("resolves IPS_DRAFT when IPS is draft", async () => {
+  it("resolves IPS_DRAFT and IPS CTA when IPS is draft", async () => {
     const userProvider: UserContextProvider = {
       getCurrentUser: vi.fn(() => ({
         userId: "u123",
@@ -61,6 +65,97 @@ describe("loadDashboardLifecycle", () => {
     const result = await loadDashboardLifecycle({ userProvider, policyRepo });
 
     expect(policyRepo.getPolicyState).toHaveBeenCalledWith("u123");
-    expect(result.lifecycleState).toBe("IPS_DRAFT");
+    expect(result).toEqual({
+      userId: "u123",
+      lifecycleState: "IPS_DRAFT",
+      nextAction: {
+        route: "/setup/ips",
+        label: "Complete IPS",
+      },
+    });
+  });
+
+  it("resolves RISK_PROFILE_MISSING and risk profile CTA when IPS is frozen", async () => {
+    const userProvider: UserContextProvider = {
+      getCurrentUser: vi.fn(() => ({
+        userId: "u123",
+        displayName: "User 123",
+        authType: "LOCAL_FAKE",
+      })),
+    };
+    const policyRepo: PolicyStateRepository = {
+      getPolicyState: vi.fn(async (userId: string) => ({
+        userId,
+        ips: {
+          ipsVersion: "v1",
+          ipsSha256: "abc123",
+          status: "FROZEN",
+          createdAtIso: "2026-02-12T00:00:00.000Z",
+          content: "ips",
+        },
+      })),
+      upsertIps: vi.fn(async () => undefined),
+      upsertRiskProfile: vi.fn(async () => undefined),
+      upsertGuidelines: vi.fn(async () => undefined),
+    };
+
+    const result = await loadDashboardLifecycle({ userProvider, policyRepo });
+
+    expect(policyRepo.getPolicyState).toHaveBeenCalledWith("u123");
+    expect(result).toEqual({
+      userId: "u123",
+      lifecycleState: "RISK_PROFILE_MISSING",
+      nextAction: {
+        route: "/setup/risk-profile",
+        label: "Complete Risk Profile",
+      },
+    });
+  });
+
+  it("resolves NO_IPS and IPS CTA when policy state exists but ips is missing", async () => {
+    const userProvider: UserContextProvider = {
+      getCurrentUser: vi.fn(() => ({
+        userId: "u123",
+        displayName: "User 123",
+        authType: "LOCAL_FAKE",
+      })),
+    };
+    const policyRepo: PolicyStateRepository = {
+      getPolicyState: vi.fn(async (userId: string) => ({
+        userId,
+      })),
+      upsertIps: vi.fn(async () => undefined),
+      upsertRiskProfile: vi.fn(async () => undefined),
+      upsertGuidelines: vi.fn(async () => undefined),
+    };
+
+    const result = await loadDashboardLifecycle({ userProvider, policyRepo });
+
+    expect(policyRepo.getPolicyState).toHaveBeenCalledWith("u123");
+    expect(result).toEqual({
+      userId: "u123",
+      lifecycleState: "NO_IPS",
+      nextAction: {
+        route: "/setup/ips",
+        label: "Set up IPS",
+      },
+    });
+  });
+
+  it("throws deterministically when user context provider throws", async () => {
+    const userProvider: UserContextProvider = {
+      getCurrentUser: vi.fn(() => {
+        throw new Error("auth unavailable");
+      }),
+    };
+    const policyRepo: PolicyStateRepository = {
+      getPolicyState: vi.fn(async () => null),
+      upsertIps: vi.fn(async () => undefined),
+      upsertRiskProfile: vi.fn(async () => undefined),
+      upsertGuidelines: vi.fn(async () => undefined),
+    };
+
+    await expect(loadDashboardLifecycle({ userProvider, policyRepo })).rejects.toThrow("auth unavailable");
+    expect(policyRepo.getPolicyState).not.toHaveBeenCalled();
   });
 });

--- a/agent/lib/dashboard/loadDashboardLifecycle.ts
+++ b/agent/lib/dashboard/loadDashboardLifecycle.ts
@@ -1,6 +1,7 @@
 import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
 import { resolveLifecycleState, type PolicyLifecycleState } from "@/lib/policy/LifecycleResolver";
 import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
+import { getNextAction, type NextAction } from "@/lib/lifecycle/nextAction";
 import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
 import type { UserContextProvider } from "@/lib/user/UserContextProvider";
 
@@ -12,6 +13,7 @@ type LoadDashboardLifecycleDeps = {
 type DashboardLifecycleResult = {
   userId: string;
   lifecycleState: PolicyLifecycleState;
+  nextAction: NextAction;
 };
 
 export async function loadDashboardLifecycle(
@@ -23,6 +25,7 @@ export async function loadDashboardLifecycle(
   const { userId } = userProvider.getCurrentUser();
   const policyState = await policyRepo.getPolicyState(userId);
   const lifecycleState = resolveLifecycleState(policyState);
+  const nextAction = getNextAction(lifecycleState);
 
-  return { userId, lifecycleState };
+  return { userId, lifecycleState, nextAction };
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ---
 
+## 2026-02-22 — Iteration APE-55 (Dashboard Lifecycle Reflects Persisted IPS)
+### Changed
+- Dashboard now resolves and exposes the current lifecycle state and next CTA route from persisted policy state for the current user (server-side).
+- Dashboard lifecycle/CTA output advances deterministically from IPS missing, IPS draft, and IPS frozen states using the existing lifecycle resolver and next-action mapping.
+
+### Manual regression checks (quick)
+- [ ] With no persisted IPS for the current user, `/dashboard` shows `NO_IPS` and next CTA route `/setup/ips`.
+- [ ] After saving an IPS draft, `/dashboard` shows `IPS_DRAFT` and next CTA route `/setup/ips`.
+- [ ] After freezing the IPS, `/dashboard` shows `RISK_PROFILE_MISSING` and next CTA route `/setup/risk-profile`.
+
 ## 2026-02-22 — Iteration APE-54 (IPS Freeze API)
 ### Added
 - Added `POST /api/ips/freeze` to transition the current user’s IPS from `DRAFT` to `FROZEN` with deterministic state handling.


### PR DESCRIPTION
## Summary
- Make /dashboard expose persisted lifecycle state and next CTA route via the existing server-side loader/resolver path.
- Extend loadDashboardLifecycle() to return deterministic 
extAction (oute, label) from the existing getNextAction() mapping.
- Add stable dashboard markers for lifecycle state and next CTA route to support testing/validation.
- Extend loader tests for NO_IPS, IPS_DRAFT, RISK_PROFILE_MISSING, and edge state policyState present without ips.
- Document dashboard behavior change in changelog.

## Validation / Findings
- Confirmed IPS_DRAFT -> /setup/ips is intentional by current getNextAction() mapping (Complete IPS).
- Confirmed /dashboard remains server-resolved (server component + server loader, no client inference).
- Added test documenting current missing-user-context behavior: loader throws (deterministic, but a follow-up hardening candidate).

## Testing
- cd agent && npm test -- lib/dashboard/loadDashboardLifecycle.test.ts
- cd agent && npm test

## Follow-up (Not Included)
- Consider a small hardening patch for deterministic dashboard behavior when user context is unavailable (redirect or explicit unauthorized state).