### PR TITLE
APE-56: Add setup IPS UI API exerciser

### DIFF
--- a/agent/app/setup/ips/page.tsx
+++ b/agent/app/setup/ips/page.tsx
@@ -1,9 +1,150 @@
-export default async function IpsSetupPage() {
+"use client";
+
+import { useState } from "react";
+
+type RequestKind = "save-draft" | "freeze";
+
+type LastResponse = {
+  requestKind: RequestKind;
+  status: number;
+  bodyText: string;
+};
+
+const DEFAULT_DRAFT_JSON = `{
+  "ipsVersion": "v1",
+  "ipsSha256": "placeholder-sha256",
+  "status": "DRAFT",
+  "createdAtIso": "2026-02-22T00:00:00.000Z",
+  "content": "IPS draft content"
+}`;
+
+function prettyPrintIfJson(text: string): string {
+  try {
+    const parsed = JSON.parse(text);
+    return JSON.stringify(parsed, null, 2);
+  } catch {
+    return text;
+  }
+}
+
+export default function IpsSetupPage() {
+  const [draftJson, setDraftJson] = useState<string>(DEFAULT_DRAFT_JSON);
+  const [clientError, setClientError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [lastResponse, setLastResponse] = useState<LastResponse | null>(null);
+
+  async function captureResponse(requestKind: RequestKind, res: Response): Promise<void> {
+    const rawText = await res.text();
+    setLastResponse({
+      requestKind,
+      status: res.status,
+      bodyText: prettyPrintIfJson(rawText),
+    });
+  }
+
+  async function onSaveDraft(): Promise<void> {
+    setClientError(null);
+
+    try {
+      JSON.parse(draftJson);
+    } catch {
+      setClientError("Invalid JSON");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/ips", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: draftJson,
+      });
+
+      await captureResponse("save-draft", res);
+    } catch (err) {
+      setLastResponse({
+        requestKind: "save-draft",
+        status: 0,
+        bodyText: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function onFreeze(): Promise<void> {
+    setClientError(null);
+    setIsSubmitting(true);
+
+    try {
+      const res = await fetch("/api/ips/freeze", {
+        method: "POST",
+      });
+
+      await captureResponse("freeze", res);
+    } catch (err) {
+      setLastResponse({
+        requestKind: "freeze",
+        status: 0,
+        bodyText: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   return (
     <main>
       <h1>IPS</h1>
-      <p>Not implemented.</p>
+      <p>Use this page to exercise the IPS draft and freeze APIs.</p>
+
+      <div style={{ display: "grid", gap: 12, maxWidth: 900 }}>
+        <label htmlFor="ips-json">IPS Draft JSON</label>
+        <textarea
+          id="ips-json"
+          value={draftJson}
+          onChange={(event) => setDraftJson(event.target.value)}
+          rows={14}
+          style={{ width: "100%", fontFamily: "monospace" }}
+        />
+
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <button type="button" onClick={onSaveDraft} disabled={isSubmitting}>
+            Save draft
+          </button>
+          <button type="button" onClick={onFreeze} disabled={isSubmitting}>
+            Freeze
+          </button>
+          <a href="/dashboard">Back to dashboard</a>
+          <a href="/dashboard" target="_blank" rel="noreferrer">
+            Open dashboard in new tab
+          </a>
+        </div>
+
+        <div>
+          <strong>Client error:</strong> {clientError ?? "None"}
+        </div>
+
+        <section>
+          <h2>Last response</h2>
+          {lastResponse ? (
+            <div style={{ display: "grid", gap: 8 }}>
+              <div>
+                <strong>Request:</strong> {lastResponse.requestKind}
+              </div>
+              <div>
+                <strong>Status:</strong> {lastResponse.status}
+              </div>
+              <div>
+                <strong>Body:</strong>
+              </div>
+              <pre style={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{lastResponse.bodyText}</pre>
+            </div>
+          ) : (
+            <p>No requests yet.</p>
+          )}
+        </section>
+      </div>
     </main>
   );
 }
-

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ---
 
+## 2026-02-22 — Iteration APE-56 (Setup IPS UI API Exerciser)
+### Changed
+- `/setup/ips` now provides a minimal UI to save IPS drafts and call IPS freeze using the existing APIs.
+- The page displays API response status and payload plainly for draft-save, freeze, and error paths.
+
+### Manual regression checks (quick)
+- [ ] Use `/setup/ips` to save a valid draft and confirm `200` response is shown, then `/dashboard` shows `IPS_DRAFT`.
+- [ ] Use `/setup/ips` to freeze and confirm `200` response is shown, then `/dashboard` shows `RISK_PROFILE_MISSING`.
+- [ ] Use `/setup/ips` freeze with no draft and confirm `409` error is shown plainly in the UI.
+
 ## 2026-02-22 — Iteration APE-55 (Dashboard Lifecycle Reflects Persisted IPS)
 ### Changed
 - Dashboard now resolves and exposes the current lifecycle state and next CTA route from persisted policy state for the current user (server-side).


### PR DESCRIPTION
## Summary
- add a minimal /setup/ips UI to exercise the IPS draft and freeze APIs without a wizard
- keep the UI as a thin API client (no lifecycle/business-rule logic)
- show request type, HTTP status, and response payload plainly for save/freeze/error paths

## What changed
- replace the /setup/ips stub with a client-side JSON textarea + Save draft / Freeze buttons
- seed a valid draft payload template for POST /api/ips (static placeholder sha + fixed ISO timestamp)
- display the last API response body with JSON pretty-print fallback to raw text
- add links back to /dashboard
- update changelog for the new user-visible setup page behavior

## Validation notes
- freeze sends POST with no body (command endpoint)
- response parsing is safe for non-JSON responses via text() + JSON parse fallback
- nested error payloads (including error.details) are preserved in the rendered response body
- Freeze is only disabled while a request is in flight (no local lifecycle/state gating)

## Testing
- cd agent && npm test
- husky pre-commit also ran 
pm test during commit (pass)