### PR TITLE
APE-60: Harden IPS API draft DTO and repo-owned metadata

### DIFF
--- a/agent/app/api/ips/route.test.ts
+++ b/agent/app/api/ips/route.test.ts
@@ -2,17 +2,19 @@ import { describe, expect, it, vi } from "vitest";
 
 import { createPostHandler } from "@/app/api/ips/route";
 import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
-import type { IpsInstance, PolicyState } from "@/lib/policy/types";
+import type { IpsInstance, IpsUpsertInput, PolicyState } from "@/lib/policy/types";
 import type { UserContextProvider } from "@/lib/user/UserContextProvider";
 import type { User } from "@/lib/user/types";
 
-function createValidDraft(overrides: Partial<IpsInstance> = {}): IpsInstance {
+type IpsDraftRequest = {
+  content: string;
+  ipsVersion?: string;
+};
+
+function createValidDraftRequest(overrides: Partial<IpsDraftRequest> = {}): IpsDraftRequest {
   return {
-    ipsVersion: "v1",
-    ipsSha256: "abc123",
-    status: "DRAFT",
-    createdAtIso: "2026-02-22T00:00:00.000Z",
     content: "IPS draft content",
+    ipsVersion: "v1",
     ...overrides,
   };
 }
@@ -30,7 +32,7 @@ function createUserProvider(userId = "u123"): UserContextProvider {
 function createPolicyRepo(overrides: Partial<PolicyStateRepository> = {}): PolicyStateRepository {
   return {
     getPolicyState: vi.fn<(userId: string) => Promise<PolicyState | null>>(async () => null),
-    upsertIps: vi.fn<(userId: string, ips: IpsInstance) => Promise<void>>(async () => undefined),
+    upsertIps: vi.fn<(userId: string, ips: IpsUpsertInput) => Promise<void>>(async () => undefined),
     upsertRiskProfile: vi.fn(async () => undefined),
     upsertGuidelines: vi.fn(async () => undefined),
     ...overrides,
@@ -42,7 +44,7 @@ describe("POST /api/ips", () => {
     const userProvider = createUserProvider("u123");
     const policyRepo = createPolicyRepo();
     const handler = createPostHandler({ userProvider, policyRepo });
-    const payload = createValidDraft();
+    const payload = createValidDraftRequest();
 
     const response = await handler(
       new Request("http://localhost/api/ips", {
@@ -57,19 +59,17 @@ describe("POST /api/ips", () => {
     expect(userProvider.getCurrentUser).toHaveBeenCalledTimes(1);
     expect(policyRepo.upsertIps).toHaveBeenCalledTimes(1);
     expect(policyRepo.upsertIps).toHaveBeenCalledWith("u123", {
-      ipsVersion: "v1",
-      ipsSha256: "abc123",
       status: "DRAFT",
-      createdAtIso: "2026-02-22T00:00:00.000Z",
       content: "IPS draft content",
+      ipsVersion: "v1",
     });
   });
 
-  it("returns 400 and does not call repo when validation fails", async () => {
+  it("accepts DTO without ipsVersion and leaves version derivation to repo", async () => {
     const userProvider = createUserProvider("u123");
     const policyRepo = createPolicyRepo();
     const handler = createPostHandler({ userProvider, policyRepo });
-    const payload = createValidDraft({ status: "FROZEN" });
+    const payload = createValidDraftRequest({ ipsVersion: undefined });
 
     const response = await handler(
       new Request("http://localhost/api/ips", {
@@ -79,11 +79,40 @@ describe("POST /api/ips", () => {
       }),
     );
 
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: "DRAFT" });
+    expect(policyRepo.upsertIps).toHaveBeenCalledWith("u123", {
+      status: "DRAFT",
+      content: "IPS draft content",
+    });
+  });
+
+  it("rejects persistence-shaped client metadata fields", async () => {
+    const userProvider = createUserProvider("u123");
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({ userProvider, policyRepo });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          content: "IPS draft content",
+          status: "DRAFT",
+          createdAtIso: "2026-02-22T00:00:00.000Z",
+          ipsSha256: "abc123",
+        }),
+      }),
+    );
+
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
       error: {
         code: "BAD_REQUEST",
-        message: "Field 'status' must be 'DRAFT' for this endpoint.",
+        message: "Request body contains unsupported fields.",
+        details: {
+          unknownFields: ["status", "createdAtIso", "ipsSha256"],
+        },
       },
     });
     expect(policyRepo.upsertIps).not.toHaveBeenCalled();
@@ -99,8 +128,8 @@ describe("POST /api/ips", () => {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          ...createValidDraft(),
-          extraField: "nope",
+          ...createValidDraftRequest(),
+          foo: "bar",
         }),
       }),
     );
@@ -111,8 +140,108 @@ describe("POST /api/ips", () => {
         code: "BAD_REQUEST",
         message: "Request body contains unsupported fields.",
         details: {
-          unknownFields: ["extraField"],
+          unknownFields: ["foo"],
         },
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when content is missing", async () => {
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ipsVersion: "v1" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Field 'content' must be a non-empty string.",
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when content is empty or whitespace", async () => {
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "   ", ipsVersion: "v1" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Field 'content' must be a non-empty string.",
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when ipsVersion is invalid when provided", async () => {
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ content: "IPS draft content", ipsVersion: "" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Field 'ipsVersion' must be a non-empty string when provided.",
+      },
+    });
+    expect(policyRepo.upsertIps).not.toHaveBeenCalled();
+  });
+
+  it.each(["null", "[]"])("returns 400 when request body is not an object (%s)", async (body) => {
+    const policyRepo = createPolicyRepo();
+    const handler = createPostHandler({
+      userProvider: createUserProvider("u123"),
+      policyRepo,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ips", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: "BAD_REQUEST",
+        message: "Request body must be an object.",
       },
     });
     expect(policyRepo.upsertIps).not.toHaveBeenCalled();
@@ -131,7 +260,7 @@ describe("POST /api/ips", () => {
       new Request("http://localhost/api/ips", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(createValidDraft()),
+        body: JSON.stringify(createValidDraftRequest()),
       }),
     );
 
@@ -158,7 +287,7 @@ describe("POST /api/ips", () => {
       new Request("http://localhost/api/ips", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(createValidDraft()),
+        body: JSON.stringify(createValidDraftRequest()),
       }),
     );
 
@@ -187,7 +316,7 @@ describe("POST /api/ips", () => {
       new Request("http://localhost/api/ips", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify(createValidDraft()),
+        body: JSON.stringify(createValidDraftRequest()),
       }),
     );
 

--- a/agent/app/api/ips/route.ts
+++ b/agent/app/api/ips/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
 import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
-import type { IpsInstance } from "@/lib/policy/types";
+import type { IpsDraftUpsertInput } from "@/lib/policy/types";
 import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
 import type { UserContextProvider } from "@/lib/user/UserContextProvider";
 
@@ -20,10 +20,10 @@ type ApiErrorBody = {
 };
 
 type ValidationResult =
-  | { ok: true; value: IpsInstance & { status: "DRAFT" } }
+  | { ok: true; value: IpsDraftUpsertInput }
   | { ok: false; message: string; details?: unknown };
 
-const ALLOWED_KEYS = ["ipsVersion", "ipsSha256", "status", "createdAtIso", "content"] as const;
+const ALLOWED_KEYS = ["ipsVersion", "content"] as const;
 
 function errorResponse(
   status: number,
@@ -63,23 +63,8 @@ function validateIpsDraftPayload(body: unknown): ValidationResult {
   }
 
   const ipsVersion = body.ipsVersion;
-  if (typeof ipsVersion !== "string" || ipsVersion.trim() === "") {
-    return { ok: false, message: "Field 'ipsVersion' must be a non-empty string." };
-  }
-
-  const ipsSha256 = body.ipsSha256;
-  if (typeof ipsSha256 !== "string" || ipsSha256.trim() === "") {
-    return { ok: false, message: "Field 'ipsSha256' must be a non-empty string." };
-  }
-
-  const status = body.status;
-  if (status !== "DRAFT") {
-    return { ok: false, message: "Field 'status' must be 'DRAFT' for this endpoint." };
-  }
-
-  const createdAtIso = body.createdAtIso;
-  if (typeof createdAtIso !== "string" || createdAtIso.trim() === "") {
-    return { ok: false, message: "Field 'createdAtIso' must be a non-empty string." };
+  if (ipsVersion !== undefined && (typeof ipsVersion !== "string" || ipsVersion.trim() === "")) {
+    return { ok: false, message: "Field 'ipsVersion' must be a non-empty string when provided." };
   }
 
   const content = body.content;
@@ -90,11 +75,9 @@ function validateIpsDraftPayload(body: unknown): ValidationResult {
   return {
     ok: true,
     value: {
-      ipsVersion,
-      ipsSha256,
       status: "DRAFT",
-      createdAtIso,
       content,
+      ...(ipsVersion === undefined ? {} : { ipsVersion }),
     },
   };
 }

--- a/agent/app/setup/ips/page.tsx
+++ b/agent/app/setup/ips/page.tsx
@@ -11,11 +11,8 @@ type LastResponse = {
 };
 
 const DEFAULT_DRAFT_JSON = `{
-  "ipsVersion": "v1",
-  "ipsSha256": "placeholder-sha256",
-  "status": "DRAFT",
-  "createdAtIso": "2026-02-22T00:00:00.000Z",
-  "content": "IPS draft content"
+  "content": "IPS draft content",
+  "ipsVersion": "v1"
 }`;
 
 function prettyPrintIfJson(text: string): string {

--- a/agent/lib/policy/JsonPolicyStateRepository.test.ts
+++ b/agent/lib/policy/JsonPolicyStateRepository.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import crypto from "node:crypto";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -47,6 +48,77 @@ describe("JsonPolicyStateRepository", () => {
       userId: "user1",
       ips,
     });
+  });
+
+  it("sets createdAtIso as draft creation time on first DTO draft save and derives metadata", async () => {
+    const repo = new JsonPolicyStateRepository();
+    const content = "IPS content";
+
+    await repo.upsertIps("user1", {
+      status: "DRAFT",
+      content,
+    });
+
+    const state = await repo.getPolicyState("user1");
+    expect(state?.userId).toBe("user1");
+    expect(state?.ips).toMatchObject({
+      ipsVersion: "v1",
+      status: "DRAFT",
+      content,
+      ipsSha256: crypto.createHash("sha256").update(content, "utf-8").digest("hex"),
+    });
+    expect(typeof state?.ips?.createdAtIso).toBe("string");
+    expect(state?.ips?.createdAtIso?.trim()).not.toBe("");
+    expect(Number.isNaN(Date.parse(state?.ips?.createdAtIso ?? ""))).toBe(false);
+  });
+
+  it("preserves createdAtIso on DTO draft overwrite and keeps existing ipsVersion when request omits it", async () => {
+    const repo = new JsonPolicyStateRepository();
+
+    await repo.upsertIps("user1", {
+      status: "DRAFT",
+      content: "First draft",
+      ipsVersion: "v9",
+    });
+    const firstState = await repo.getPolicyState("user1");
+    const firstCreatedAtIso = firstState?.ips?.createdAtIso;
+
+    await repo.upsertIps("user1", {
+      status: "DRAFT",
+      content: "Second draft",
+    });
+    const secondState = await repo.getPolicyState("user1");
+
+    expect(firstCreatedAtIso).toBeDefined();
+    expect(secondState?.ips).toMatchObject({
+      ipsVersion: "v9",
+      status: "DRAFT",
+      content: "Second draft",
+      createdAtIso: firstCreatedAtIso,
+      ipsSha256: crypto.createHash("sha256").update("Second draft", "utf-8").digest("hex"),
+    });
+  });
+
+  it("creates a new draft creation timestamp when replacing a frozen IPS with a DTO draft", async () => {
+    const repo = new JsonPolicyStateRepository();
+    const frozenIps: IpsInstance = {
+      ipsVersion: "v1",
+      ipsSha256: "abc123",
+      status: "FROZEN",
+      createdAtIso: "2026-02-11T00:00:00.000Z",
+      content: "Frozen content",
+    };
+
+    await repo.upsertIps("user1", frozenIps);
+    await repo.upsertIps("user1", {
+      status: "DRAFT",
+      content: "New draft after freeze",
+    });
+
+    const state = await repo.getPolicyState("user1");
+    expect(state?.ips?.status).toBe("DRAFT");
+    expect(state?.ips?.ipsVersion).toBe("v1");
+    expect(state?.ips?.createdAtIso).not.toBe(frozenIps.createdAtIso);
   });
 
   it("upsertRiskProfile merges without deleting ips", async () => {

--- a/agent/lib/policy/JsonPolicyStateRepository.ts
+++ b/agent/lib/policy/JsonPolicyStateRepository.ts
@@ -1,8 +1,18 @@
+import crypto from "node:crypto";
 import path from "node:path";
 
 import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
-import type { GuidelinesInstance, IpsInstance, PolicyState, RiskProfile } from "@/lib/policy/types";
+import type {
+  GuidelinesInstance,
+  IpsDraftUpsertInput,
+  IpsInstance,
+  IpsUpsertInput,
+  PolicyState,
+  RiskProfile,
+} from "@/lib/policy/types";
 import { atomicWriteJson, ensureDirExists, readJsonIfExists, safeUserIdToFilename } from "@/lib/policy/storage";
+
+const DEFAULT_IPS_VERSION = "v1";
 
 function resolveStorageRoot(): string {
   const configured = process.env.POLICY_STATE_DIR?.trim();
@@ -25,8 +35,19 @@ export class JsonPolicyStateRepository implements PolicyStateRepository {
     return await readJsonIfExists<PolicyState>(filePath);
   }
 
-  async upsertIps(userId: string, ips: IpsInstance): Promise<void> {
-    await this.upsert(userId, { ips });
+  async upsertIps(userId: string, ips: IpsUpsertInput): Promise<void> {
+    const filePath = this.filePathForUser(userId);
+    await ensureDirExists(this.rootDir);
+
+    const existing = await readJsonIfExists<PolicyState>(filePath);
+    const normalizedIps = isPersistedIpsInstance(ips) ? ips : this.normalizeDraftIpsInput(ips, existing?.ips);
+    const nextState: PolicyState = {
+      ...(existing ?? { userId }),
+      ips: normalizedIps,
+      userId,
+    };
+
+    await atomicWriteJson(filePath, nextState);
   }
 
   async upsertRiskProfile(userId: string, risk: RiskProfile): Promise<void> {
@@ -55,4 +76,32 @@ export class JsonPolicyStateRepository implements PolicyStateRepository {
     const fileName = safeUserIdToFilename(userId);
     return path.join(this.rootDir, fileName);
   }
+
+  private normalizeDraftIpsInput(input: IpsDraftUpsertInput, existingIps?: IpsInstance): IpsInstance {
+    const ipsVersion = input.ipsVersion ?? existingIps?.ipsVersion ?? DEFAULT_IPS_VERSION;
+    // `createdAtIso` is the draft creation timestamp, so draft overwrites preserve it.
+    // A new draft created after a frozen IPS gets a fresh creation timestamp.
+    const createdAtIso =
+      existingIps?.status === "DRAFT" && typeof existingIps.createdAtIso === "string" && existingIps.createdAtIso.trim() !== ""
+        ? existingIps.createdAtIso
+        : new Date().toISOString();
+
+    return {
+      ipsVersion,
+      ipsSha256: crypto.createHash("sha256").update(input.content, "utf-8").digest("hex"),
+      status: "DRAFT",
+      createdAtIso,
+      content: input.content,
+    };
+  }
+}
+
+function isPersistedIpsInstance(input: IpsUpsertInput): input is IpsInstance {
+  return (
+    typeof input.ipsVersion === "string" &&
+    typeof input.ipsSha256 === "string" &&
+    typeof input.createdAtIso === "string" &&
+    (input.status === "DRAFT" || input.status === "FROZEN") &&
+    typeof input.content === "string"
+  );
 }

--- a/agent/lib/policy/PolicyStateRepository.ts
+++ b/agent/lib/policy/PolicyStateRepository.ts
@@ -1,8 +1,8 @@
-import type { GuidelinesInstance, IpsInstance, PolicyState, RiskProfile } from "@/lib/policy/types";
+import type { GuidelinesInstance, IpsUpsertInput, PolicyState, RiskProfile } from "@/lib/policy/types";
 
 export interface PolicyStateRepository {
   getPolicyState(userId: string): Promise<PolicyState | null>;
-  upsertIps(userId: string, ips: IpsInstance): Promise<void>;
+  upsertIps(userId: string, ips: IpsUpsertInput): Promise<void>;
   upsertRiskProfile(userId: string, risk: RiskProfile): Promise<void>;
   upsertGuidelines(userId: string, guidelines: GuidelinesInstance): Promise<void>;
 }

--- a/agent/lib/policy/types.ts
+++ b/agent/lib/policy/types.ts
@@ -6,6 +6,14 @@ export interface IpsInstance {
   content: string;
 }
 
+export interface IpsDraftUpsertInput {
+  status: "DRAFT";
+  content: string;
+  ipsVersion?: string;
+}
+
+export type IpsUpsertInput = IpsInstance | IpsDraftUpsertInput;
+
 export interface RiskProfile {
   version: string;
   status: "MISSING" | "FROZEN";

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@
 
 ---
 
+## 2026-02-22 — Iteration APE-60 (IPS Draft DTO Contract Hardening)
+### Changed
+- `POST /api/ips` now accepts a draft DTO with `content` and optional `ipsVersion` instead of the persistence-shaped IPS payload.
+- Client-supplied IPS metadata fields (for example `status`, `createdAtIso`, `ipsSha256`) are rejected with `BAD_REQUEST`; the server/repository enforces `DRAFT` status and owns persisted metadata.
+- `/setup/ips` now seeds and submits the draft DTO shape for save-draft testing.
+
+### Manual regression checks (quick)
+- [ ] Use `/setup/ips` to save a valid draft DTO and confirm `200` response is shown, then `/dashboard` shows `IPS_DRAFT`.
+- [ ] Send `POST /api/ips` with extra fields like `status` or `ipsSha256` and confirm `400` with `error.details.unknownFields`.
+- [ ] Use `/setup/ips` freeze after saving a draft and confirm freeze still returns `200` and `/dashboard` advances to `RISK_PROFILE_MISSING`.
+
 ## 2026-02-22 — Iteration APE-56 (Setup IPS UI API Exerciser)
 ### Changed
 - `/setup/ips` now provides a minimal UI to save IPS drafts and call IPS freeze using the existing APIs.


### PR DESCRIPTION
Summary
- Harden POST /api/ips to accept only a draft DTO (content + optional ipsVersion) and reject persistence-shaped fields.
- Move IPS draft metadata ownership to the repository (derive ipsSha256, own createdAtIso, preserve draft creation timestamp on draft overwrite).
- Update /setup/ips seeded payload and tests/changelog for the DTO contract.

Behavior notes
- No public response shape changes.
- Client-supplied IPS metadata fields (status, createdAtIso, ipsSha256) are rejected with BAD_REQUEST unknownFields.
- createdAtIso semantics are clarified as draft creation time (preserved on draft overwrite; refreshed when replacing a frozen IPS with a new draft).

Docs impact
- ARCHITECTURE: no (no system boundary change)
- CHANGELOG: yes (POST /api/ips request contract and /setup/ips payload shape changed)
- ADR: no (no durable architectural decision change)

Testing
- cd agent && npm test -- app/api/ips/route.test.ts
- cd agent && npm test -- lib/policy/JsonPolicyStateRepository.test.ts
- cd agent && npm test