### PR TITLE
APE-61 — Replace substring error matching with typed RepoError

### DIFF
--- a/agent/app/api/ips/freeze/route.test.ts
+++ b/agent/app/api/ips/freeze/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createPostHandler } from "@/app/api/ips/freeze/route";
+import { RepoError } from "@/lib/policy/errors";
 import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
 import type { IpsInstance, PolicyState } from "@/lib/policy/types";
 import type { UserContextProvider } from "@/lib/user/UserContextProvider";
@@ -242,7 +243,7 @@ describe("POST /api/ips/freeze", () => {
         ips: createIps({ status: "DRAFT" }),
       })),
       upsertIps: vi.fn(async () => {
-        throw new Error("Invalid userId format: bad/user");
+        throw new RepoError("INVALID_USER_ID", "Invalid userId format", { userId: "bad/user" });
       }),
     });
     const handler = createPostHandler({
@@ -259,6 +260,9 @@ describe("POST /api/ips/freeze", () => {
       error: {
         code: "BAD_REQUEST",
         message: "Invalid user identifier.",
+        details: {
+          reason: "INVALID_USER_ID",
+        },
       },
     });
   });

--- a/agent/app/api/ips/freeze/route.ts
+++ b/agent/app/api/ips/freeze/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
+import { isRepoError } from "@/lib/policy/errors";
 import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
 import type { IpsInstance } from "@/lib/policy/types";
 import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
@@ -81,8 +82,10 @@ async function validateCommandBody(req: Request): Promise<EmptyBodyValidationRes
 }
 
 function mapUnexpectedError(err: unknown): NextResponse<ApiErrorBody> {
-  if (err instanceof Error && err.message.includes("Invalid userId format")) {
-    return errorResponse(400, "BAD_REQUEST", "Invalid user identifier.");
+  if (isRepoError(err)) {
+    if (err.code === "INVALID_USER_ID") {
+      return errorResponse(400, "BAD_REQUEST", "Invalid user identifier.", { reason: err.code });
+    }
   }
 
   return errorResponse(500, "INTERNAL", "Internal error");

--- a/agent/app/api/ips/route.test.ts
+++ b/agent/app/api/ips/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createPostHandler } from "@/app/api/ips/route";
+import { RepoError } from "@/lib/policy/errors";
 import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
 import type { IpsInstance, IpsUpsertInput, PolicyState } from "@/lib/policy/types";
 import type { UserContextProvider } from "@/lib/user/UserContextProvider";
@@ -251,7 +252,7 @@ describe("POST /api/ips", () => {
     const userProvider = createUserProvider("bad/user");
     const policyRepo = createPolicyRepo({
       upsertIps: vi.fn(async () => {
-        throw new Error("Invalid userId format: bad/user");
+        throw new RepoError("INVALID_USER_ID", "Invalid userId format", { userId: "bad/user" });
       }),
     });
     const handler = createPostHandler({ userProvider, policyRepo });
@@ -270,6 +271,9 @@ describe("POST /api/ips", () => {
       error: {
         code: "BAD_REQUEST",
         message: "Invalid user identifier.",
+        details: {
+          reason: "INVALID_USER_ID",
+        },
       },
     });
   });

--- a/agent/app/api/ips/route.ts
+++ b/agent/app/api/ips/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
+import { isRepoError } from "@/lib/policy/errors";
 import type { PolicyStateRepository } from "@/lib/policy/PolicyStateRepository";
 import type { IpsDraftUpsertInput } from "@/lib/policy/types";
 import { LocalUserContextProvider } from "@/lib/user/LocalUserContextProvider";
@@ -83,8 +84,10 @@ function validateIpsDraftPayload(body: unknown): ValidationResult {
 }
 
 function mapUnexpectedError(err: unknown): NextResponse<ApiErrorBody> {
-  if (err instanceof Error && err.message.includes("Invalid userId format")) {
-    return errorResponse(400, "BAD_REQUEST", "Invalid user identifier.");
+  if (isRepoError(err)) {
+    if (err.code === "INVALID_USER_ID") {
+      return errorResponse(400, "BAD_REQUEST", "Invalid user identifier.", { reason: err.code });
+    }
   }
 
   return errorResponse(500, "INTERNAL", "Internal error");

--- a/agent/lib/policy/JsonPolicyStateRepository.test.ts
+++ b/agent/lib/policy/JsonPolicyStateRepository.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { JsonPolicyStateRepository } from "@/lib/policy/JsonPolicyStateRepository";
+import { RepoError } from "@/lib/policy/errors";
 import type { GuidelinesInstance, IpsInstance, RiskProfile } from "@/lib/policy/types";
 
 describe("JsonPolicyStateRepository", () => {
@@ -191,8 +192,16 @@ describe("JsonPolicyStateRepository", () => {
       content: "IPS content",
     };
 
-    await expect(repo.upsertIps("../bad-user", ips)).rejects.toThrow("Invalid userId format");
-    await expect(repo.getPolicyState("../bad-user")).rejects.toThrow("Invalid userId format");
+    await expect(repo.upsertIps("../bad-user", ips)).rejects.toMatchObject({
+      name: "RepoError",
+      code: "INVALID_USER_ID",
+      message: "Invalid userId format",
+    });
+    await expect(repo.getPolicyState("../bad-user")).rejects.toMatchObject({
+      name: "RepoError",
+      code: "INVALID_USER_ID",
+      message: "Invalid userId format",
+    });
   });
 
   it("unsafe userId throws for slash", async () => {
@@ -205,7 +214,11 @@ describe("JsonPolicyStateRepository", () => {
       content: "IPS content",
     };
 
-    await expect(repo.upsertIps("bad/user", ips)).rejects.toThrow("Invalid userId format");
+    await expect(repo.upsertIps("bad/user", ips)).rejects.toMatchObject({
+      name: "RepoError",
+      code: "INVALID_USER_ID",
+      message: "Invalid userId format",
+    });
   });
 
   it("unsafe userId throws for spaces", async () => {
@@ -217,7 +230,24 @@ describe("JsonPolicyStateRepository", () => {
       summary: "Risk summary",
     };
 
-    await expect(repo.upsertRiskProfile("bad user", risk)).rejects.toThrow("Invalid userId format");
+    await expect(repo.upsertRiskProfile("bad user", risk)).rejects.toMatchObject({
+      name: "RepoError",
+      code: "INVALID_USER_ID",
+      message: "Invalid userId format",
+    });
+  });
+
+  it("invalid userId throws RepoError", async () => {
+    const repo = new JsonPolicyStateRepository();
+    const ips: IpsInstance = {
+      ipsVersion: "v1",
+      ipsSha256: "abc123",
+      status: "DRAFT",
+      createdAtIso: "2026-02-11T00:00:00.000Z",
+      content: "IPS content",
+    };
+
+    await expect(repo.upsertIps("bad/user", ips)).rejects.toBeInstanceOf(RepoError);
   });
 
   it("deterministic write formatting creates parseable json", async () => {

--- a/agent/lib/policy/errors.ts
+++ b/agent/lib/policy/errors.ts
@@ -1,0 +1,37 @@
+export type RepoErrorCode = "INVALID_USER_ID";
+
+export class RepoError extends Error {
+  readonly code: RepoErrorCode;
+  readonly details?: Record<string, unknown>;
+
+  constructor(code: RepoErrorCode, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.name = "RepoError";
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function isRepoError(error: unknown): error is RepoError {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const candidate = error as {
+    name?: unknown;
+    code?: unknown;
+    message?: unknown;
+    details?: unknown;
+  };
+
+  const hasValidDetails =
+    candidate.details === undefined ||
+    (typeof candidate.details === "object" && candidate.details !== null && !Array.isArray(candidate.details));
+
+  return (
+    candidate.name === "RepoError" &&
+    typeof candidate.code === "string" &&
+    typeof candidate.message === "string" &&
+    hasValidDetails
+  );
+}

--- a/agent/lib/policy/storage.ts
+++ b/agent/lib/policy/storage.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import { RepoError } from "@/lib/policy/errors";
 
 const SAFE_USER_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
@@ -8,7 +9,7 @@ export async function ensureDirExists(dirPath: string): Promise<void> {
 
 export function safeUserIdToFilename(userId: string): string {
   if (!SAFE_USER_ID_PATTERN.test(userId)) {
-    throw new Error(`Invalid userId format: ${userId}`);
+    throw new RepoError("INVALID_USER_ID", "Invalid userId format", { userId });
   }
 
   return `${userId}.json`;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ---
 
+## 2026-02-28 — Iteration APE-61 (API Error Semantics Hardening)
+### Changed
+- API routes now map known repository failures using typed error codes rather than parsing error message substrings.
+- Invalid user identifier failures are returned deterministically as `400` with `error.code = "BAD_REQUEST"` and `error.details.reason = "INVALID_USER_ID"`.
+
+### Manual regression checks (quick)
+- [ ] `POST /api/ips` with an invalid user context identifier returns `400` with `error.details.reason = "INVALID_USER_ID"`.
+- [ ] `POST /api/ips/freeze` with an invalid user context identifier returns `400` with `error.details.reason = "INVALID_USER_ID"`.
+- [ ] Unexpected internal repository errors still return `500` with a generic message and no stack details.
+
 ## 2026-02-22 — Iteration APE-60 (IPS Draft DTO Contract Hardening)
 ### Changed
 - `POST /api/ips` now accepts a draft DTO with `content` and optional `ipsVersion` instead of the persistence-shaped IPS payload.


### PR DESCRIPTION
## Summary
Hardens API error semantics by replacing brittle error-message substring matching with deterministic typed error mapping for known repository failures.

## What changed
- Introduced a minimal typed repository error model (`RepoError`) with a structural type guard.
- Repository invalid user identifier failures now throw `INVALID_USER_ID` as a typed error.
- `POST /api/ips` and `POST /api/ips/freeze` map known typed repository errors deterministically (no message parsing).
- Unexpected failures continue to return generic, non-leaky `500 INTERNAL` responses.

## Mapping decision (locked)
- Known failure: `INVALID_USER_ID`
- HTTP: `400 BAD_REQUEST`
- Error envelope (shape unchanged):
```json
{
  "error": {
    "code": "BAD_REQUEST",
    "message": "Invalid user identifier.",
    "details": { "reason": "INVALID_USER_ID" }
  }
}
```

## Tests
- Added/updated route tests to assert typed error mapping for `INVALID_USER_ID`.
- Preserved regression coverage for success, validation failures, unauthorized user context, and unexpected error paths.
- Full test suite passes.

## Docs impact
- ARCHITECTURE: no
- CHANGELOG: yes
- ADR: no

## Manual regression checks (quick)
- `POST /api/ips` with invalid user identifier returns `400` with `error.details.reason = "INVALID_USER_ID"`.
- `POST /api/ips/freeze` with invalid user identifier returns `400` with `error.details.reason = "INVALID_USER_ID"`.
- Unexpected internal errors still return `500` with generic message and no stack/details leak.
